### PR TITLE
Get the balance of the account by its address implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 
+sudo: required
+
+dist: xenial
+
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
 
 install:
   - pip install -r requirements.txt
@@ -15,7 +17,7 @@ script:
   - cat requirements.txt requirements-tests.txt requirements-dev.txt | safety check --stdin
   - radon cc cli -nb --total-average
   - isort -rc cli --diff && isort -rc tests --diff
-  - flake8 cli
+  - flake8 cli && flake8 tests
   - coverage run -m pytest -vv tests
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@
   
 ## Getting started
 
-Blank.
+Install the package from the [PypI](https://pypi.org/project/remme-core-cli) through [pip](https://github.com/pypa/pip):
+
+```bash
+$ pip3 install remme-core-cli
+```
 
 ## Usage
 
@@ -43,6 +47,22 @@ Options:
   --help     Show this message and exit.
 
 ...
+```
+
+### Account
+
+Get balance of the account by its address — ``remme account get-balance``:
+
+| Arguments  | Type     |  Required  | Description                                         |
+| :--------: | :------: | :--------: | --------------------------------------------------- |
+| address    | String   |  Yes       | Get balance of the account by its address.          |
+| node-url   | String   |  No        | Apply the command to the specified node by its URL. |
+
+```bash
+$ remme account get-balance \
+      --address=1120076ecf036e857f42129b58303bcf1e03723764a1702cbe98529802aad8514ee3cf \
+      --node-url=node-genesis-testnet.remme.io
+368440.0
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Options:
 
 Get balance of the account by its address — ``remme account get-balance``:
 
-| Arguments  | Type     |  Required  | Description                                         |
-| :--------: | :------: | :--------: | --------------------------------------------------- |
-| address    | String   |  Yes       | Get balance of the account by its address.          |
-| node-url   | String   |  No        | Apply the command to the specified node by its URL. |
+| Arguments | Type   |  Required | Description                                         |
+| :-------: | :----: | :-------: | --------------------------------------------------- |
+| address   | String |  Yes      | Get balance of the account by its address.          |
+| node-url  | String |  No       | Apply the command to the specified node by its URL. |
 
 ```bash
 $ remme account get-balance \

--- a/cli/account/help.py
+++ b/cli/account/help.py
@@ -1,0 +1,4 @@
+"""
+Provide help messages for command line interface's account commands.
+"""
+GET_ACCOUNT_BALANCE_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Get balance of the account by its address.'

--- a/cli/account/interfaces.py
+++ b/cli/account/interfaces.py
@@ -1,0 +1,15 @@
+"""
+Provide implementation of the account interfaces.
+"""
+
+
+class AccountInterface:
+    """
+    Implements account interface.
+    """
+
+    async def get_balance(self, address):
+        """
+        Get balance of the account by its address.
+        """
+        pass

--- a/cli/account/service.py
+++ b/cli/account/service.py
@@ -1,11 +1,12 @@
 """
 Provide implementation of the account.
 """
-import asyncio
+from accessify import implements
 
-loop = asyncio.get_event_loop()
+from cli.account.interfaces import AccountInterface
 
 
+@implements(AccountInterface)
 class Account:
     """
     Implements account.
@@ -20,8 +21,8 @@ class Account:
         """
         self.service = service
 
-    def get_balance(self, address):
+    async def get_balance(self, address):
         """
         Get balance of the account by its address.
         """
-        return loop.run_until_complete(self.service.token.get_balance(address=address))
+        return await self.service.token.get_balance(address=address)

--- a/cli/clis/account.py
+++ b/cli/clis/account.py
@@ -1,0 +1,37 @@
+"""
+Provide implementation of the command line interface's account commands.
+"""
+import click
+from remme import Remme
+
+from cli.services.account import Account
+
+GET_ACCOUNT_BALANCE_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Get balance of the account by its address.'
+NODE_URL_ARGUMENT_HELP_MESSAGE = 'Apply the command to the specified node by its URL.'
+
+
+@click.group('account', chain=True)
+def account_commands():
+    """
+    Provide commands for working with account.
+    """
+    pass
+
+
+@click.option('--address', type=str, required=True, help=GET_ACCOUNT_BALANCE_ADDRESS_ARGUMENT_HELP_MESSAGE)
+@click.option('--node-url', type=str, help=NODE_URL_ARGUMENT_HELP_MESSAGE)
+@account_commands.command('get-balance')
+def get_balance(address, node_url):
+    """
+    Get balance of the account by its address.
+    """
+    if node_url is None:
+        node_url = 'localhost'
+
+    remme = Remme(private_key_hex=None, network_config={
+        'node_address': str(node_url) + ':8080',
+        'ssl_mode': False,
+    })
+
+    balance = Account(service=remme).get_balance(address=address)
+    click.echo(balance)

--- a/cli/constants.py
+++ b/cli/constants.py
@@ -1,0 +1,8 @@
+"""
+Provide constants for command line interface.
+"""
+ADDRESS_REGEXP = '[0-9a-f]{70}'
+
+FAILED_EXIT_FROM_COMMAND = -1
+
+NODE_URL_ARGUMENT_HELP_MESSAGE = 'Apply the command to the specified node by its URL.'

--- a/cli/entrypoint.py
+++ b/cli/entrypoint.py
@@ -3,7 +3,7 @@ Provide implementation of the command line interface to interact with Remme-core
 """
 import click
 
-from cli.clis.account import account_commands
+from cli.account.cli import account_commands
 
 
 @click.group()

--- a/cli/entrypoint.py
+++ b/cli/entrypoint.py
@@ -3,6 +3,8 @@ Provide implementation of the command line interface to interact with Remme-core
 """
 import click
 
+from cli.clis.account import account_commands
+
 
 @click.group()
 @click.version_option()
@@ -12,3 +14,6 @@ def cli():
     Command-line interface to interact with Remme-core.
     """
     pass
+
+
+cli.add_command(account_commands)

--- a/cli/services/account.py
+++ b/cli/services/account.py
@@ -1,0 +1,27 @@
+"""
+Provide implementation of the account.
+"""
+import asyncio
+
+loop = asyncio.get_event_loop()
+
+
+class Account:
+    """
+    Implements account.
+    """
+
+    def __init__(self, service):
+        """
+        Constructor.
+
+        Arguments:
+            service: object to interact with Remme core API.
+        """
+        self.service = service
+
+    def get_balance(self, address):
+        """
+        Get balance of the account by its address.
+        """
+        return loop.run_until_complete(self.service.token.get_balance(address=address))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ flake8-docstrings==1.3.0
 flake8-commas==2.0.0
 flake8-comprehensions==2.1.0
 flake8-per-file-ignores==0.8.1
-flake8-print==3.1.0
 isort==4.3.17
 pep8-naming==0.8.2
 safety==1.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 accessify==0.3.1
+asyncio==3.4.3
 click==7.0
+remme==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,10 @@ combine_as_imports=True
 
 [flake8]
 max-line-length=120
-ignore=D200, D413, D107
+ignore=D200, D413, D107, D100
 per-file-ignores=
-    */__init__.py: D104, F401
+    */__init__.py: D104, F401, D100,
+    tests/test_*: D205
 
 [coverage:run]
 omit =

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt', 'r') as f:
     requirements = f.read().splitlines()
 
 setup(
-    version='0.1.0',
+    version='0.1.1',
     name='remme-core-cli',
     description='The command-line interface (CLI) that provides a set of commands to interact with Remme-core.',
     long_description=long_description,
@@ -31,8 +31,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
 
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1309

### Description

Get the balance of the account by its address command line interface's command implementation.

| Arguments  | Type     |  Required  | Description                                         |
| :--------: | :------: | :--------: | --------------------------------------------------- |
| address    | String   |  Yes       | Get balance of the account by its address.          |
| node-url   | String   |  No        | Apply the command to the specified node by its URL. |

Example of the usage:

```bash
$ remme account get-balance \
      --address=1120076ecf036e857f42129b58303bcf1e03723764a1702cbe98529802aad8514ee3cf \
      --node-url=node-1-testnet.remme.io
368440.0
```

### Implemented
— Command line interface's command.
— Service to get the balance of the account class.

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with `Remme-core` — https://github.com/Remmeauth/remme-client-python
