### PR TITLE
Create configurations implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ docker exec -it remme-core-cli bash
 And now being in the container, you can develop the project. For instance, run tests and linters:
 
 ```bash
-# pytest tests/
+# pytest -vv tests/
 # flake8 cli && flake8 tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,32 @@ $ pip3 install remme-core-cli
 
 ## Usage
 
+### Configuration file
+
+Using the command line interface, you will have an option to declare the `node URL` to send commands to as illustrated below:
+
+```bash
+$ remme account get-balance \
+      --address=1120076ecf036e857f42129b58303bcf1e03723764a1702cbe98529802aad8514ee3cf \
+      --node-url=node-genesis-testnet.remme.io
+```
+
+You shouldn't declare node url every time when you execute a command, use configuration file instead. Configuration file 
+is required to be named `.remme-core-cli.yml` and located in the home directory (`~/`).
+
+The configuration file have an optional section to declare `node URL` to send commands to:
+
+```bash
+node:
+  url: node-genesis-testnet.remme.io
+```
+
+Try it out by downloading the example of the configuration file to the home directory.
+
+```bash
+$ curl https://git.io/fjYZS > ~/.remme-core-cli.yml
+```
+
 ### Service
 
 Get the version of the package — ``remme --version``:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     * [Requirements](#getting-started-requirements)
     * [Installation](#installation)
   * [Usage](#usage)
+    * [Configuration file](#configuration-file)
     * [Service](#service)
     * [Account](#account)
   * [Development](#development)
@@ -48,20 +49,19 @@ $ remme account get-balance \
       --node-url=node-genesis-testnet.remme.io
 ```
 
-You shouldn't declare node url every time when you execute a command, use configuration file instead. Configuration file 
+You shouldn't declare `node URL` every time when you execute a command, use configuration file instead. Configuration file 
 is required to be named `.remme-core-cli.yml` and located in the home directory (`~/`).
 
 The configuration file have an optional section to declare `node URL` to send commands to:
 
 ```bash
-node:
-  url: node-genesis-testnet.remme.io
+node-url: node-genesis-testnet.remme.io
 ```
 
 Try it out by downloading the example of the configuration file to the home directory.
 
 ```bash
-$ curl https://git.io/fjYZS > ~/.remme-core-cli.yml
+$ curl -L https://git.io/fjYZS > ~/.remme-core-cli.yml
 ```
 
 ### Service

--- a/assets/.remme-core-cli.yml
+++ b/assets/.remme-core-cli.yml
@@ -1,0 +1,2 @@
+node:
+  url: node-genesis-testnet.remme.io

--- a/assets/.remme-core-cli.yml
+++ b/assets/.remme-core-cli.yml
@@ -1,2 +1,1 @@
-node:
-  url: node-genesis-testnet.remme.io
+node-url: node-genesis-testnet.remme.io

--- a/cli/config.py
+++ b/cli/config.py
@@ -1,0 +1,55 @@
+"""
+Provide implementation of the Remme Core CLI checking configurations manipulating.
+"""
+import pathlib
+
+import yaml
+from accessify import private
+
+from cli.constants import REMME_CORE_CLI_CONFIG_FILE_NAME
+
+
+class ConfigParameters:
+    """
+    Configuration parameters data transfer object.
+    """
+
+    def __init__(self, node_url):
+        self._node_url = node_url
+
+    @property
+    def node_url(self):
+        """
+        Get configuration file's node url.
+        """
+        return self._node_url
+
+
+class ConfigFile:
+    """
+    Implementation of Remme Core CLI configuration file.
+    """
+
+    @property
+    def path(self):
+        """
+        Get path pointing to the user's home directory.
+        """
+        return str(pathlib.Path.home())
+
+    @private
+    def read(self, name=REMME_CORE_CLI_CONFIG_FILE_NAME):
+        """
+        Read configuration file.
+        Return dictionary.
+        """
+        with open(self.path + '/.' + name + '.yml') as f:
+            return yaml.safe_load(f)
+
+    def parse(self):
+        """
+        Parse configuration file.
+        """
+        config_as_dict = self.read()
+
+        return ConfigParameters(node_url=config_as_dict.get('node').get('url'))

--- a/cli/config.py
+++ b/cli/config.py
@@ -1,5 +1,5 @@
 """
-Provide implementation of the Remme Core CLI checking configurations manipulating.
+Provide implementation of the CLI configurations file.
 """
 import pathlib
 
@@ -27,7 +27,7 @@ class ConfigParameters:
 
 class ConfigFile:
     """
-    Implementation of Remme Core CLI configuration file.
+    Implementation of command line interface configuration file.
     """
 
     @property
@@ -38,19 +38,24 @@ class ConfigFile:
         return str(pathlib.Path.home())
 
     @private
-    def read(self, name=CLI_CONFIG_FILE_NAME):
+    def read(self, name):
         """
         Read configuration file.
 
         Return dictionary.
         """
-        with open(self.path + '/.' + name + '.yml') as f:
-            return yaml.safe_load(f)
+        with open(self.path + '/.' + name + '.yml') as config_file:
+            return yaml.safe_load(config_file)
 
-    def parse(self):
+    def parse(self, name=CLI_CONFIG_FILE_NAME):
         """
         Parse configuration file.
         """
-        config_as_dict = self.read()
+        config_as_dict = self.read(name=name)
 
-        return ConfigParameters(node_url=config_as_dict.get('node').get('url'))
+        if config_as_dict is None:
+            return ConfigParameters(node_url=None)
+
+        node_url = config_as_dict.get('node-url')
+
+        return ConfigParameters(node_url=node_url)

--- a/cli/constants.py
+++ b/cli/constants.py
@@ -1,0 +1,1 @@
+REMME_CORE_CLI_CONFIG_FILE_NAME = 'remme-core-cli'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,3 +41,37 @@ def create_config_file():
     yield
 
     os.remove(path_to_copy_fixture_file_to)
+
+
+@pytest.yield_fixture()
+def create_config_file_without_node_url():
+    """
+    Create configuration file without node url for testing.
+
+    The example of the configuration file is located in the tests fixture folder.
+    """
+    fixture_file_path = os.getcwd() + '/tests/fixtures/.remme-core-cli-without-url.yml'
+    path_to_copy_fixture_file_to = str(pathlib.Path.home()) + '/.remme-core-cli-without-url.yml'
+
+    shutil.copyfile(fixture_file_path, path_to_copy_fixture_file_to)
+
+    yield
+
+    os.remove(path_to_copy_fixture_file_to)
+
+
+@pytest.yield_fixture()
+def create_empty_config_file():
+    """
+    Create empty configuration file for testing.
+
+    The example of the configuration file is located in the tests fixture folder.
+    """
+    fixture_file_path = os.getcwd() + '/tests/fixtures/.remme-core-cli-empty-file.yml'
+    path_to_copy_fixture_file_to = str(pathlib.Path.home()) + '/.remme-core-cli-empty-file.yml'
+
+    shutil.copyfile(fixture_file_path, path_to_copy_fixture_file_to)
+
+    yield
+
+    os.remove(path_to_copy_fixture_file_to)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 """
 Provide configurations for testing.
 """
+import os
 import pathlib
+import shutil
 import sys
+
+import pytest
 
 
 def pytest_configure():
@@ -20,3 +24,20 @@ def pytest_configure():
         - https://docs.pytest.org/en/latest/goodpractices.html#tests-outside-application-code
     """
     sys.path.insert(0, str(pathlib.Path(__file__).parents[1]))
+
+
+@pytest.yield_fixture()
+def create_config_file():
+    """
+    Create configuration file for testing.
+
+    The example of the configuration file is located in the tests fixture folder.
+    """
+    fixture_file_path = os.getcwd() + '/tests/fixtures/.remme-core-cli.yml'
+    path_to_copy_fixture_file_to = str(pathlib.Path.home()) + '/.remme-core-cli.yml'
+
+    shutil.copyfile(fixture_file_path, path_to_copy_fixture_file_to)
+
+    yield
+
+    os.remove(path_to_copy_fixture_file_to)

--- a/tests/fixtures/.remme-core-cli-without-url.yml
+++ b/tests/fixtures/.remme-core-cli-without-url.yml
@@ -1,0 +1,1 @@
+node-url:

--- a/tests/fixtures/.remme-core-cli.yml
+++ b/tests/fixtures/.remme-core-cli.yml
@@ -1,0 +1,2 @@
+node:
+  url: node-genesis-testnet.remme.io

--- a/tests/fixtures/.remme-core-cli.yml
+++ b/tests/fixtures/.remme-core-cli.yml
@@ -1,2 +1,1 @@
-node:
-  url: node-genesis-testnet.remme.io
+node-url: node-genesis-testnet.remme.io

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,10 @@
+"""
+Provide tests for implementation of the config commands.
+"""
 from cli.config import ConfigFile
+
+CLI_CONFIG_FILE_NAME_EMPTY_FILE = 'remme-core-cli-empty-file'
+CLI_CONFIG_FILE_NAME_WITHOUT_URL = 'remme-core-cli-without-url'
 
 
 def test_get_node_url(create_config_file):
@@ -9,3 +15,23 @@ def test_get_node_url(create_config_file):
     config = ConfigFile().parse()
 
     assert config.node_url == 'node-genesis-testnet.remme.io'
+
+
+def test_get_node_url_without_node_url(create_config_file_without_node_url):
+    """
+    Case: get node url from configuration file without node url.
+    Expect: none is returned.
+    """
+    config = ConfigFile().parse(name=CLI_CONFIG_FILE_NAME_WITHOUT_URL)
+
+    assert config.node_url is None
+
+
+def test_get_node_url_from_empty_file(create_empty_config_file):
+    """
+    Case: get node url from empty configuration file.
+    Expect: none is returned.
+    """
+    config = ConfigFile().parse(name=CLI_CONFIG_FILE_NAME_EMPTY_FILE)
+
+    assert config.node_url is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+from cli.config import ConfigFile
+
+
+def test_get_node_url(create_config_file):
+    """
+    Case: get node url from configuration file.
+    Expect: node url address in string format.
+    """
+    config = ConfigFile().parse()
+
+    assert config.node_url == 'node-genesis-testnet.remme.io'


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1323

### Description
Using the command line interface, you will have an option to declare the `node URL` to send commands to as illustrated below:

```bash
$ remme account get-balance \
      --address=1120076ecf036e857f42129b58303bcf1e03723764a1702cbe98529802aad8514ee3cf \
      --node-url=node-genesis-testnet.remme.io
```

You shouldn't declare node url every time when you execute a command, use configuration file instead. Configuration file is required to be named `.remme-core-cli.yml` and located in the home directory (`~/`).

The configuration file have an optional section to declare `node URL` to send commands to:

```bash
node:
  url: node-genesis-testnet.remme.io
```

Try it out by downloading the example of the configuration file to the home directory.

```bash
$ cur -L https://git.io/fjYZS > ~/.remme-core-cli.yml
```

### References
- PyYAML Documentation — https://pyyaml.org/wiki/PyYAMLDocumentation