### PR TITLE
REM-1366: Integrate configuration file reading to the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Run the ``Docker container`` with the project source code in the background mode
 
 ```bash
 $ docker build -t remme-core-cli . -f Dockerfile.development
-$ docker run -d -v $PWD:/remme-core-cli --name remme-core-cli remme-core-cli
+$ docker run -d --network host -v $PWD:/remme-core-cli --name remme-core-cli remme-core-cli
 ```
 
 Enter the container bash:

--- a/cli/account/cli.py
+++ b/cli/account/cli.py
@@ -15,6 +15,7 @@ from cli.constants import (
     FAILED_EXIT_FROM_COMMAND,
     NODE_URL_ARGUMENT_HELP_MESSAGE,
 )
+from cli.utils import default_node_url
 
 loop = asyncio.get_event_loop()
 
@@ -28,7 +29,7 @@ def account_commands():
 
 
 @click.option('--address', type=str, required=True, help=GET_ACCOUNT_BALANCE_ADDRESS_ARGUMENT_HELP_MESSAGE)
-@click.option('--node-url', type=str, help=NODE_URL_ARGUMENT_HELP_MESSAGE)
+@click.option('--node-url', type=str, required=False, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
 @account_commands.command('get-balance')
 def get_balance(address, node_url):
     """
@@ -38,14 +39,9 @@ def get_balance(address, node_url):
         click.echo('The following address `{address}` is not valid.'.format(address=address))
         sys.exit(FAILED_EXIT_FROM_COMMAND)
 
-    if node_url is None:
-        node_url = 'localhost'
+    remme = Remme(network_config={'node_address': str(node_url) + ':8080'})
 
-    remme = Remme(private_key_hex=None, network_config={
-        'node_address': str(node_url) + ':8080',
-    })
-
-    account = Account(service=remme)
-    balance = loop.run_until_complete(account.get_balance(address=address))
+    account_service = Account(service=remme)
+    balance = loop.run_until_complete(account_service.get_balance(address=address))
 
     click.echo(balance)

--- a/cli/config.py
+++ b/cli/config.py
@@ -44,8 +44,12 @@ class ConfigFile:
 
         Return dictionary.
         """
-        with open(self.path + '/.' + name + '.yml') as config_file:
-            return yaml.safe_load(config_file)
+        try:
+            with open(self.path + '/.' + name + '.yml') as config_file:
+                return yaml.safe_load(config_file)
+
+        except FileNotFoundError:
+            return
 
     def parse(self, name=CLI_CONFIG_FILE_NAME):
         """

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -3,9 +3,24 @@ Provide utils for command line interface.
 """
 import json
 
+from cli.config import ConfigFile
+
 
 def dict_to_pretty_json(data):
     """
     Convert dictionary to string with indents as human readable text.
     """
     return json.dumps(data, indent=4, sort_keys=True)
+
+
+def default_node_url():
+    """
+    Get default node URL.
+    """
+    config_parameters = ConfigFile().parse()
+
+    if config_parameters.node_url is None:
+        return 'localhost'
+
+    else:
+        return config_parameters.node_url

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,3 +35,13 @@ def test_get_node_url_from_empty_file(create_empty_config_file):
     config = ConfigFile().parse(name=CLI_CONFIG_FILE_NAME_EMPTY_FILE)
 
     assert config.node_url is None
+
+
+def test_get_node_url_without_file():
+    """
+    Case: get node url without configuration file.
+    Expect: none is returned.
+    """
+    config = ConfigFile().parse()
+
+    assert config.node_url is None


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1366

### Description

Using the command line interface, you will have an option to declare the `node URL` to send commands to as illustrated below:

```bash
$ remme account get-balance \
      --address=1120076ecf036e857f42129b58303bcf1e03723764a1702cbe98529802aad8514ee3cf \
      --node-url=node-genesis-testnet.remme.io
```

You shouldn't declare `node URL` every time when you execute a command, use configuration file instead. Configuration file is required to be named `.remme-core-cli.yml` and located in the home directory (`~/`).

The configuration file have an optional section to declare `node URL` to send commands to:

```bash
node-url: node-genesis-testnet.remme.io
```

Try it out by downloading the example of the configuration file to the home directory.

```bash
$ curl -L https://git.io/fj3Mi > ~/.remme-core-cli.yml
```

The `node URL` will be read every time from the configuration file (`.remme-core-cli.yml`) unless you provide it in the command line interface:

```bash
$ remme account get-balance \
      --address=1120076ecf036e857f42129b58303bcf1e03723764a1702cbe98529802aad8514ee3cf
```

If you do not provide the `node URL` neither in the command line interface nor in the configuration file, `node URL` will be equal to `localhost` by default.
