### PR TITLE
Implement getting node information

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,24 @@ $ remme node get-peers --node-url=node-genesis-testnet.remme.io
 }
 ```
 
+Get node information — ``remme node get-info``:
+
+| Arguments | Type   | Required | Description                     |
+| :-------: | :----: | :------: | ------------------------------- |
+| node-url  | String | No       | Node URL to apply a command to. |
+
+```bash
+$ remme node get-info --node-url=node-27-testnet.remme.io
+{
+    "result": {
+        "information": {
+            "is_synced": true,
+            "peer_count": 3
+        }
+    }
+}
+```
+
 ### Public key
 
 Get a list of the addresses of the public keys by account address — ``remme public-key get-list``:

--- a/cli/node/cli.py
+++ b/cli/node/cli.py
@@ -12,6 +12,7 @@ from cli.constants import (
 )
 from cli.node.forms import (
     GetNodeConfigurationsForm,
+    GetNodeInformationForm,
     GetNodePeersForm,
 )
 from cli.node.service import Node
@@ -80,6 +81,35 @@ def get_peers(node_url):
     })
 
     result, errors = Node(service=remme).get_peers()
+
+    if errors is not None:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    print_result(result=result)
+
+
+@click.option('--node-url', type=str, required=False, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
+@node_commands.command('get-info')
+def get_node_info(node_url):
+    """
+    Get node information.
+    """
+    arguments, errors = GetNodeInformationForm().load({
+        'node_url': node_url,
+    })
+
+    if errors:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    node_url = arguments.get('node_url')
+
+    remme = Remme(network_config={
+        'node_address': str(node_url) + ':8080',
+    })
+
+    result, errors = Node(service=remme).get_info()
 
     if errors is not None:
         print_errors(errors=errors)

--- a/cli/node/forms.py
+++ b/cli/node/forms.py
@@ -20,3 +20,11 @@ class GetNodePeersForm(Schema):
     """
 
     node_url = NodeURLField(allow_none=True, required=False)
+
+
+class GetNodeInformationForm(Schema):
+    """
+    Get node information.
+    """
+
+    node_url = NodeURLField(required=False)

--- a/cli/node/interfaces.py
+++ b/cli/node/interfaces.py
@@ -19,3 +19,9 @@ class NodeInterface:
         Get the node's peers.
         """
         pass
+
+    def get_info(self):
+        """
+        Get node information.
+        """
+        pass

--- a/cli/node/service.py
+++ b/cli/node/service.py
@@ -52,3 +52,17 @@ class Node:
         return {
             'peers': peers,
         }, None
+
+    def get_info(self):
+        """
+        Get node information.
+        """
+        try:
+            information = loop.run_until_complete(self.service.node_management.get_node_info())
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'information': information.data,
+        }, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,22 @@ class NodeConfigurations:
         }
 
 
+class NodeInformation:
+    """
+    Impose node information data transfer object.
+    """
+
+    @property
+    def data(self):
+        """
+        Get node information.
+        """
+        return {
+            'is_synced': True,
+            'peer_count': 3,
+        }
+
+
 @pytest.fixture()
 def sent_transaction():
     """
@@ -181,7 +197,7 @@ def sent_transaction():
 
 
 @pytest.fixture()
-def public_key_info():
+def public_key_information():
     """
     Get public key information fixture.
     """
@@ -194,3 +210,11 @@ def node_configurations():
     Get node configurations fixture.
     """
     return NodeConfigurations()
+
+
+@pytest.fixture()
+def node_information():
+    """
+    Get node information fixture.
+    """
+    return NodeInformation()

--- a/tests/node/test_get_info.py
+++ b/tests/node/test_get_info.py
@@ -1,0 +1,138 @@
+"""
+Provide tests for command line interface's node get information command.
+"""
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from cli.constants import (
+    FAILED_EXIT_FROM_COMMAND_CODE,
+    NODE_27_IN_TESTNET_ADDRESS,
+    PASSED_EXIT_FROM_COMMAND_CODE,
+)
+from cli.entrypoint import cli
+from cli.utils import dict_to_pretty_json
+
+
+def test_get_node_info():
+    """
+    Case: get node information.
+    Expect: flag is synced and peer count are returned.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node',
+        'get-info',
+        '--node-url',
+        NODE_27_IN_TESTNET_ADDRESS,
+    ])
+
+    node_information = json.loads(result.output).get('result').get('information')
+
+    node_is_synced = node_information.get('is_synced')
+    node_peer_count = node_information.get('peer_count')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert isinstance(node_is_synced, bool)
+    assert isinstance(node_peer_count, int)
+
+
+def test_get_node_info_without_node_url(mocker, node_information):
+    """
+    Case: get node information without passing node URL.
+    Expect:flag is synced and peer count are returned from node on localhost.
+    """
+    mock_node_get_info = mocker.patch('cli.node.service.loop.run_until_complete')
+    mock_node_get_info.return_value = node_information
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node',
+        'get-info',
+    ])
+
+    expected_node_information = {
+        'result': {
+            'information': node_information.data,
+        },
+    }
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert expected_node_information == json.loads(result.output)
+
+
+def test_get_node_info_invalid_node_url():
+    """
+    Case: get node information by passing invalid node URL.
+    Expect: the following node URL is invalid error message.
+    """
+    invalid_node_url = 'domainwithoutextention'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node',
+        'get-info',
+        '--node-url',
+        invalid_node_url,
+    ])
+
+    expected_error = {
+        'errors': {
+            'node_url': [
+                f'The following node URL `{invalid_node_url}` is invalid.',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+@pytest.mark.parametrize('node_url_with_protocol', ['http://masternode.com', 'https://masternode.com'])
+def test_get_node_info_node_url_with_protocol(node_url_with_protocol):
+    """
+    Case: get node information by passing node URL with explicit protocol.
+    Expect: the following node URL contains protocol error message.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node',
+        'get-info',
+        '--node-url',
+        node_url_with_protocol,
+    ])
+
+    expected_error = {
+        'errors': {
+            'node_url': [
+                f'Pass the following node URL `{node_url_with_protocol}` without protocol (http, https, etc.).',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+def test_get_node_info_non_existing_node_url():
+    """
+    Case: get node information by passing non-existing node URL.
+    Expect: check if node running at URL error message.
+    """
+    non_existing_node_url = 'non-existing-node.com'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node',
+        'get-info',
+        '--node-url',
+        non_existing_node_url,
+    ])
+
+    expected_error = {
+        'errors': f'Please check if your node running at http://{non_existing_node_url}:8080.',
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output

--- a/tests/public_key/test_get_public_key_info.py
+++ b/tests/public_key/test_get_public_key_info.py
@@ -76,13 +76,13 @@ def test_get_public_key_info_invalid_address():
     assert dict_to_pretty_json(expected_error) in result.output
 
 
-def test_get_public_key_info_without_node_url(mocker, public_key_info):
+def test_get_public_key_info_without_node_url(mocker, public_key_information):
     """
     Case: get information about public key without passing node URL.
     Expect: dictionary of public key information is returned from node on localhost.
     """
     mock_public_key_get_info = mocker.patch('cli.public_key.service.loop.run_until_complete')
-    mock_public_key_get_info.return_value = public_key_info
+    mock_public_key_get_info.return_value = public_key_information
 
     runner = CliRunner()
     result = runner.invoke(cli, [
@@ -94,7 +94,7 @@ def test_get_public_key_info_without_node_url(mocker, public_key_info):
 
     expected_result = {
         'result': {
-            'information': public_key_info.data,
+            'information': public_key_information.data,
         },
     }
 


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1314

### Description

Getting node information command line interface's command implementation.

| Arguments | Type   |  Required | Description                       |
| :-------: | :----: | :-------: | ---------------------------------- |
| node-url  | String |  No       | Node URL to apply a command to. |

Example of the usage:

```bash
$ remme node get-info --node-url=node-27-testnet.remme.io
{
    "result": {
        "information": {
            "is_synced": true,
            "peer_count": 3
        }
    }
}
```

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with `Remme-core` — https://github.com/Remmeauth/remme-client-python
