### PR TITLE
REM-1303: Fetch particular state by address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     * [Account](#account)
     * [Node](#node)
     * [Public key](#public-key)
+    * [State](#state)
     * [Transaction](#transaction)
   * [Development](#development)
     * [Requirements](#development-requirements)
@@ -250,6 +251,8 @@ $ remme public-key get-info \
 }
 ```
 
+### State
+
 Get a state by its address — ``remme state get``:
 
 | Arguments | Type   | Required | Description                        |
@@ -259,13 +262,13 @@ Get a state by its address — ``remme state get``:
 
 ```bash
 $ remme state get \
-      --address=0000000000000000000000000000000000000000000000000000000000000000000001 \
+      --address=000000a87cb5eafdcca6a8cde0fb0dec1400c5ab274474a6aa82c12840f169a04216b7 \
       --node-url=node-6-testnet.remme.io
 {
     "result": {
         "state": {
-            "data": "CAE=",
-            "head": "2f7c6645c8e95c42ee229e14c64a80e382e3b3ef4edf73fadbc8f3605f4588ad2e9272264d138278057de2f7961dcc962b4b89713cf69d256299a6635532017b"
+            "data": "CmwKJnNhd3Rvb3RoLnNldHRpbmdzLnZvdGUuYXV0aG9yaXplZF9rZXlzEkIwMmE2NTc5NmYyNDkwOTFjMzA4NzYxNGI0ZDljMjkyYjAwYjhlYmE1ODBkMDQ1YWMyZmQ3ODEyMjRiODdiNmYxM2U=",
+            "head": "95d78133eb98628d5ff17c7d1972b9ab03e50fceeb8e199d98cb52078550f5473bb001e57c116238697bdc1958eaf6d5f096f7b66974e1ea46b9c9da694be9d9"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -326,15 +326,15 @@ $ remme state get \
 
 Get a list of transactions — ``remme transaction get-list``:
 
-| Arguments   | Type   |  Required | Description                                                    |
-| :---------: | :----: | :-------: | -------------------------------------------------------------- |
-| ids         | String |  No       | Identifiers to get a list of transactions by.                  |
+| Arguments   | Type   |  Required | Description                                            |
+| :---------: | :----: | :-------: | -----------------------------------------------------  |
+| ids         | String |  No       | Identifiers to get a list of transactions by.          |
 | start       | String |  No       | Transaction identifier to get a list transaction starting from.|
-| limit       | Integer|  No       | Maximum amount of transactions to return.                      |
-| head        | String |  No       | Block identifier to get a list of transactions from.           |
-| reverse     | Bool   |  No       | Parameter to reverse result.                                   |
-| node-url    | String |  No       | Node URL to apply a command to.                                |
-| family-name | String |  No       | List of transactions by its family name.                       |
+| limit       | Integer|  No       | Maximum amount of transactions to return.              |
+| head        | String |  No       | Block identifier to get a list of transactions from.   |
+| reverse     | Bool   |  No       | Parameter to reverse result.                           |
+| node-url    | String |  No       | Node URL to apply a command to.                        |
+| family-name | String |  No       | List of transactions by its family name.               |
 
 ```bash
 $ remme transaction get-list \

--- a/README.md
+++ b/README.md
@@ -308,15 +308,15 @@ $ remme state get \
 
 Get a list of transactions — ``remme transaction get-list``:
 
-| Arguments   | Type   |  Required | Description                                            |
-| :---------: | :----: | :-------: | -----------------------------------------------------  |
-| ids         | String |  No       | Identifiers to get a list of transactions by.          |
+| Arguments   | Type   |  Required | Description                                                    |
+| :---------: | :----: | :-------: | -------------------------------------------------------------- |
+| ids         | String |  No       | Identifiers to get a list of transactions by.                  |
 | start       | String |  No       | Transaction identifier to get a list transaction starting from.|
-| limit       | Integer|  No       | Maximum amount of transactions to return.              |
-| head        | String |  No       | Block identifier to get a list of transactions from.   |
-| reverse     | Bool   |  No       | Parameter to reverse result.                           |
-| node-url    | String |  No       | Node URL to apply a command to.                        |
-| family-name | String |  No       | List of transactions by its family name.               |
+| limit       | Integer|  No       | Maximum amount of transactions to return.                      |
+| head        | String |  No       | Block identifier to get a list of transactions from.           |
+| reverse     | Bool   |  No       | Parameter to reverse result.                                   |
+| node-url    | String |  No       | Node URL to apply a command to.                                |
+| family-name | String |  No       | List of transactions by its family name.                       |
 
 ```bash
 $ remme transaction get-list \

--- a/README.md
+++ b/README.md
@@ -250,6 +250,27 @@ $ remme public-key get-info \
 }
 ```
 
+Get a state by its address — ``remme state get``:
+
+| Arguments | Type   | Required | Description                        |
+| :-------: | :----: | :------: | ---------------------------------- |
+| address   | String | Yes      | Account address to get a state by. |
+| node-url  | String | No       | Node URL to apply a command to.    |
+
+```bash
+$ remme state get \
+      --address=0000000000000000000000000000000000000000000000000000000000000000000001 \
+      --node-url=node-6-testnet.remme.io
+{
+    "result": {
+        "state": {
+            "data": "CAE=",
+            "head": "2f7c6645c8e95c42ee229e14c64a80e382e3b3ef4edf73fadbc8f3605f4588ad2e9272264d138278057de2f7961dcc962b4b89713cf69d256299a6635532017b"
+        }
+    }
+}
+```
+
 ### Transaction
 
 Get a list of transactions — ``remme transaction get-list``:

--- a/cli/entrypoint.py
+++ b/cli/entrypoint.py
@@ -7,6 +7,7 @@ from cli.account.cli import account_commands
 from cli.atomic_swap.cli import atomic_swap_commands
 from cli.node.cli import node_commands
 from cli.public_key.cli import public_key_commands
+from cli.state.cli import state_command
 from cli.transaction.cli import transaction_command
 
 
@@ -24,4 +25,5 @@ cli.add_command(account_commands)
 cli.add_command(atomic_swap_commands)
 cli.add_command(node_commands)
 cli.add_command(public_key_commands)
+cli.add_command(state_command)
 cli.add_command(transaction_command)

--- a/cli/state/cli.py
+++ b/cli/state/cli.py
@@ -11,7 +11,7 @@ from cli.constants import (
     NODE_URL_ARGUMENT_HELP_MESSAGE,
 )
 from cli.state.forms import GetStateForm
-from cli.state.help import STATE_ADDRESS_ARGUMENT_HELP_MESSAGE
+from cli.state.help import STATE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE
 from cli.state.service import State
 from cli.utils import (
     default_node_url,
@@ -28,7 +28,7 @@ def state_command():
     pass
 
 
-@click.option('--address', required=True, type=str, help=STATE_ADDRESS_ARGUMENT_HELP_MESSAGE)
+@click.option('--address', required=True, type=str, help=STATE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE)
 @click.option('--node-url', required=False, type=str, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
 @state_command.command('get')
 def get_state(address, node_url):

--- a/cli/state/cli.py
+++ b/cli/state/cli.py
@@ -51,10 +51,10 @@ def get_state(address, node_url):
         'node_address': str(node_url) + ':8080',
     })
 
-    state, errors = State(service=remme).get(address=address)
+    result, errors = State(service=remme).get(address=address)
 
     if errors is not None:
         print_errors(errors=errors)
         sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
 
-    print_result(result=state)
+    print_result(result=result)

--- a/cli/state/cli.py
+++ b/cli/state/cli.py
@@ -1,0 +1,60 @@
+"""
+Provide implementation of the command line interface's state commands.
+"""
+import sys
+
+import click
+from remme import Remme
+
+from cli.constants import (
+    FAILED_EXIT_FROM_COMMAND_CODE,
+    NODE_URL_ARGUMENT_HELP_MESSAGE,
+)
+from cli.state.forms import GetStateForm
+from cli.state.help import STATE_ADDRESS_ARGUMENT_HELP_MESSAGE
+from cli.state.service import State
+from cli.utils import (
+    default_node_url,
+    print_errors,
+    print_result,
+)
+
+
+@click.group('state', chain=True)
+def state_command():
+    """
+    Provide commands for working with state.
+    """
+    pass
+
+
+@click.option('--address', required=True, type=str, help=STATE_ADDRESS_ARGUMENT_HELP_MESSAGE)
+@click.option('--node-url', required=False, type=str, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
+@state_command.command('get')
+def get_state(address, node_url):
+    """
+    Get a state by its address.
+    """
+    arguments, errors = GetStateForm().load({
+        'address': address,
+        'node_url': node_url,
+    })
+
+    if errors:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    address = arguments.get('address')
+    node_url = arguments.get('node_url')
+
+    remme = Remme(network_config={
+        'node_address': str(node_url) + ':8080',
+    })
+
+    state, errors = State(service=remme).get(address=address)
+
+    if errors is not None:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    print_result(result=state)

--- a/cli/state/forms.py
+++ b/cli/state/forms.py
@@ -1,0 +1,18 @@
+"""
+Provide forms for command line interface's state commands.
+"""
+from marshmallow import Schema
+
+from cli.generic.forms.fields import (
+    AccountAddressField,
+    NodeUrlField,
+)
+
+
+class GetStateForm(Schema):
+    """
+    Get a state by its address form.
+    """
+
+    address = AccountAddressField(required=True)
+    node_url = NodeUrlField(required=False)

--- a/cli/state/help.py
+++ b/cli/state/help.py
@@ -1,0 +1,4 @@
+"""
+Provide help messages for command line interface's state commands.
+"""
+STATE_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Account address to get a state by.'

--- a/cli/state/help.py
+++ b/cli/state/help.py
@@ -1,4 +1,4 @@
 """
 Provide help messages for command line interface's state commands.
 """
-STATE_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Account address to get a state by.'
+STATE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Account address to get a state by.'

--- a/cli/state/interfaces.py
+++ b/cli/state/interfaces.py
@@ -1,0 +1,15 @@
+"""
+Provide implementation of the state interfaces.
+"""
+
+
+class StateInterface:
+    """
+    Implements state interface.
+    """
+
+    def get(self, address):
+        """
+        Get a state by its address.
+        """
+        pass

--- a/cli/state/service.py
+++ b/cli/state/service.py
@@ -1,0 +1,46 @@
+"""
+Provide implementation of the state.
+"""
+import asyncio
+
+from accessify import implements
+from aiohttp_json_rpc import RpcGenericServerDefinedError
+
+from cli.state.interfaces import StateInterface
+
+loop = asyncio.get_event_loop()
+
+
+@implements(StateInterface)
+class State:
+    """
+    Implements state.
+    """
+
+    def __init__(self, service):
+        """
+        Constructor.
+
+        Arguments:
+            service: object to interact with Remme core API.
+        """
+        self.service = service
+
+    def get(self, address):
+        """
+        Get a state by its address.
+        """
+        try:
+            state = loop.run_until_complete(
+                self.service.blockchain_info.get_state_by_address(address=address),
+            )
+
+        except RpcGenericServerDefinedError as error:
+            return None, str(error.message)
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'state': state,
+        }, None

--- a/cli/transaction/service.py
+++ b/cli/transaction/service.py
@@ -35,9 +35,11 @@ class Transaction:
             start (string, optional): transaction identifier to get a list transaction starting from.
             limit (int, optional): maximum amount of transactions to return.
             head (string, optional): block identifier to get a list of transactions from.
-            reverse (bool, optional): parameter to reverse result.
+            reverse (string, optional): parameter to reverse result.
             family_name (string, optional): list of a transactions by its family name.
         """
+        reverse = '' if reverse else 'false'
+
         try:
             transactions = loop.run_until_complete(
                 self.service.blockchain_info.get_transactions(query={

--- a/cli/transaction/service.py
+++ b/cli/transaction/service.py
@@ -35,11 +35,9 @@ class Transaction:
             start (string, optional): transaction identifier to get a list transaction starting from.
             limit (int, optional): maximum amount of transactions to return.
             head (string, optional): block identifier to get a list of transactions from.
-            reverse (string, optional): parameter to reverse result.
+            reverse (bool, optional): parameter to reverse result.
             family_name (string, optional): list of a transactions by its family name.
         """
-        reverse = '' if reverse else 'false'
-
         try:
             transactions = loop.run_until_complete(
                 self.service.blockchain_info.get_transactions(query={

--- a/tests/state/test_get_state.py
+++ b/tests/state/test_get_state.py
@@ -38,7 +38,6 @@ def test_get_state_with_address():
 
     assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
     assert re.match(pattern=HEADER_SIGNATURE_REGEXP, string=result_header_signature) is not None
-    assert isinstance(json.loads(result.output), dict)
 
 
 def test_get_state_with_invalid_address():

--- a/tests/state/test_get_state.py
+++ b/tests/state/test_get_state.py
@@ -1,0 +1,146 @@
+"""
+Provide tests for command line interface's get state command.
+"""
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from cli.constants import (
+    FAILED_EXIT_FROM_COMMAND_CODE,
+    NODE_IP_ADDRESS_FOR_TESTING,
+    PASSED_EXIT_FROM_COMMAND_CODE,
+)
+from cli.entrypoint import cli
+from cli.utils import dict_to_pretty_json
+
+ADDRESS_WITH_STATE = '0000000000000000000000000000000000000000000000000000000000000000000001'
+
+
+def test_get_state_with_address():
+    """
+    Case: get a state by its address.
+    Expect: state is returned.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'state',
+        'get',
+        '--address',
+        ADDRESS_WITH_STATE,
+        '--node-url',
+        NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert isinstance(json.loads(result.output), dict)
+
+
+def test_get_state_with_invalid_address():
+    """
+    Case: get a state by its invalid address.
+    Expect: the following address is invalid error message.
+    """
+    invalid_address = '044c7db163cf2'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'state',
+        'get',
+        '--address',
+        invalid_address,
+        '--node-url',
+        NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    expected_error_message = {
+        'errors': {
+            'address': [
+                f'The following address `{invalid_address}` is invalid.',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error_message) in result.output
+
+
+def test_get_state_without_node_url(mocker):
+    """
+    Case: get a state by its address without passing node URL.
+    Expect: state is returned from node on localhost.
+    """
+    expected_result = {
+        "data": "CAE=",
+        "head": "2f7c6645c8e95c42ee229e14c64a80e382e3b3ef4edf73fadbc8f3605f4588ad"
+                "2e9272264d138278057de2f7961dcc962b4b89713cf69d256299a6635532017b",
+    }
+
+    mock_get_state_by_address = mocker.patch('cli.state.service.loop.run_until_complete')
+    mock_get_state_by_address.return_value = expected_result
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'state',
+        'get',
+        '--address',
+        ADDRESS_WITH_STATE,
+    ])
+
+    result_output = json.loads(result.output).get('result').get('state')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert expected_result == result_output
+
+
+def test_get_state_with_invalid_node_url():
+    """
+    Case: get a state by passing invalid node URL.
+    Expect: the following node URL is invalid error message.
+    """
+    invalid_node_url = 'my-node-url.com'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'state',
+        'get',
+        '--address',
+        ADDRESS_WITH_STATE,
+        '--node-url',
+        invalid_node_url,
+    ])
+
+    expected_error_message = {
+        'errors': f'Please check if your node running at http://{invalid_node_url}:8080.',
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error_message) in result.output
+
+
+@pytest.mark.parametrize('node_url_with_protocol', ['http://masternode.com', 'https://masternode.com'])
+def test_get_state_node_url_with_protocol(node_url_with_protocol):
+    """
+    Case: get a state by passing node URL with explicit protocol.
+    Expect: the following node URL contains protocol error message.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'state',
+        'get',
+        '--address',
+        ADDRESS_WITH_STATE,
+        '--node-url',
+        node_url_with_protocol,
+    ])
+
+    expected_error = {
+        'errors': {
+            'node_url': [
+                f'Pass the following node URL `{node_url_with_protocol}` without protocol (http, https, etc.).',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output

--- a/tests/transaction/test_get_list_transactions.py
+++ b/tests/transaction/test_get_list_transactions.py
@@ -95,8 +95,8 @@ def test_get_list_transactions_with_ids():
         NODE_IP_ADDRESS_FOR_TESTING,
     ])
 
-    expected_header_signature = '044c7db163cf21ab9eafc9b267693e2d732411056c7530e54282946ec47cc180' \
-                                '201e7be5612a671a7028474ad18e3738e676c17a86b7180fc1aad4c97e38b85b'
+    expected_header_signature = '6601e240044b00db4b7e5eda7800e88236341077879a4a9cf5a1b1f9fb2ece87' \
+                                '7bc9a43808d429e68f4d65ee8d7231e4e8711e705ad51be7888d1a7f25b57717'
 
     result_header_signature = json.loads(result.output).get('result').get('data')[0].get('header_signature')
 

--- a/tests/transaction/test_get_list_transactions.py
+++ b/tests/transaction/test_get_list_transactions.py
@@ -95,8 +95,8 @@ def test_get_list_transactions_with_ids():
         NODE_IP_ADDRESS_FOR_TESTING,
     ])
 
-    expected_header_signature = '6601e240044b00db4b7e5eda7800e88236341077879a4a9cf5a1b1f9fb2ece87' \
-                                '7bc9a43808d429e68f4d65ee8d7231e4e8711e705ad51be7888d1a7f25b57717'
+    expected_header_signature = '044c7db163cf21ab9eafc9b267693e2d732411056c7530e54282946ec47cc180' \
+                                '201e7be5612a671a7028474ad18e3738e676c17a86b7180fc1aad4c97e38b85b'
 
     result_header_signature = json.loads(result.output).get('result').get('data')[0].get('header_signature')
 


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1303

### Description
Get state by its address command line interface's command implementation.

Example of the usage:

| Arguments | Type   | Required | Description                        |
| :-------: | :----: | :------: | ---------------------------------- |
| address   | String | Yes      | Account address to get a state by. |
| node-url  | String | No       | Node URL to apply a command to.    |

```bash
$ remme state get \
      --address=000000a87cb5eafdcca6a8cde0fb0dec1400c5ab274474a6aa82c12840f169a04216b7 \
      --node-url=node-6-testnet.remme.io
{
    "result": {
        "state": {
            "data": "CmwKJnNhd3Rvb3RoLnNldHRpbmdzLnZvdGUuYXV0aG9yaXplZF9rZXlzEkIwMmE2NTc5NmYyNDkwOTFjMzA4NzYxNGI0ZDljMjkyYjAwYjhlYmE1ODBkMDQ1YWMyZmQ3ODEyMjRiODdiNmYxM2U=",
            "head": "95d78133eb98628d5ff17c7d1972b9ab03e50fceeb8e199d98cb52078550f5473bb001e57c116238697bdc1958eaf6d5f096f7b66974e1ea46b9c9da694be9d9"
        }
    }
}
```

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with Remme-core — https://github.com/Remmeauth/remme-client-python
