### PR TITLE
REM-1313: Implement getting only identifiers of batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Get a list of batches — ``remme batch get-list``:
 | limit       | Integer|  No       | Maximum amount of batches to return.                    |
 | head        | String |  No       | Block identifier to get a list of batches from.         |
 | reverse     | Bool   |  No       | Parameter to reverse result.                            |
+| ids-only    | Bool   |  No       | The flag to get a list of batches' identifiers.         |
 | node-url    | String |  No       | Node URL to apply a command to.                         |
 
 ```bash
@@ -577,7 +578,19 @@ $ remme batch get-list \
         }
     ]
 }
+```
 
+Get a list of batches' identifiers (can be combined with other parameters like `--limit`):
+
+```bash
+$ remme batch get-list --ids-only --node-url=node-6-testnet.remme.io
+{
+    "result": [
+        "e4d5089f2ef1...6b0f185b3b6ca",
+        "df5e555f...317f039501",
+        ...
+    ]
+}
 ```
 
 ### Node

--- a/cli/batch/cli.py
+++ b/cli/batch/cli.py
@@ -15,6 +15,7 @@ from cli.batch.help import (
     BATCH_HEAD_ARGUMENT_HELP_MESSAGE,
     BATCH_ID_ARGUMENT_HELP_MESSAGE,
     BATCH_IDENTIFIERS_ARGUMENT_HELP_MESSAGE,
+    BATCH_IDENTIFIERS_ONLY_ARGUMENT_HELP_MESSAGE,
     BATCH_LIMIT_ARGUMENT_HELP_MESSAGE,
     BATCH_REVERSE_ARGUMENT_HELP_MESSAGE,
     BATCH_START_ARGUMENT_HELP_MESSAGE,
@@ -109,9 +110,10 @@ def get_batch_status(id, node_url):
 @click.option('--limit', required=False, type=int, help=BATCH_LIMIT_ARGUMENT_HELP_MESSAGE)
 @click.option('--head', required=False, type=str, help=BATCH_HEAD_ARGUMENT_HELP_MESSAGE)
 @click.option('--reverse', required=False, is_flag=True, help=BATCH_REVERSE_ARGUMENT_HELP_MESSAGE)
+@click.option('--ids-only', required=False, is_flag=True, help=BATCH_IDENTIFIERS_ONLY_ARGUMENT_HELP_MESSAGE)
 @click.option('--node-url', required=False, type=str, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
 @batch_commands.command('get-list')
-def get_batches(ids, start, limit, head, reverse, node_url):
+def get_batches(ids, start, limit, head, reverse, ids_only, node_url):
     """
     Get a list of batches.
     """
@@ -121,6 +123,7 @@ def get_batches(ids, start, limit, head, reverse, node_url):
         'limit': limit,
         'head': head,
         'reverse': reverse,
+        'ids_only': ids_only,
         'node_url': node_url,
     })
 
@@ -132,19 +135,29 @@ def get_batches(ids, start, limit, head, reverse, node_url):
     start = arguments.get('start')
     limit = arguments.get('limit')
     head = arguments.get('head')
+    ids_only = arguments.get('ids_only')
     node_url = arguments.get('node_url')
 
     remme = Remme(network_config={
         'node_address': str(node_url) + ':8080',
     })
 
-    result, errors = Batch(service=remme).get_list(
-        ids=batch_ids,
-        start=start,
-        limit=limit,
-        head=head,
-        reverse=reverse,
-    )
+    if ids_only:
+        result, errors = Batch(service=remme).get_list_ids(
+            ids=batch_ids,
+            start=start,
+            limit=limit,
+            head=head,
+            reverse=reverse,
+        )
+    else:
+        result, errors = Batch(service=remme).get_list(
+            ids=batch_ids,
+            start=start,
+            limit=limit,
+            head=head,
+            reverse=reverse,
+        )
 
     if errors is not None:
         print_errors(errors=errors)

--- a/cli/batch/forms.py
+++ b/cli/batch/forms.py
@@ -48,4 +48,5 @@ class GetBatchesListForm(Schema):
             validate.Range(min=1, error='Limit must be greater than 0.'),
         ],
     )
+    ids_only = fields.Boolean(required=False)
     node_url = NodeUrlField(required=False)

--- a/cli/batch/help.py
+++ b/cli/batch/help.py
@@ -8,3 +8,4 @@ BATCH_HEAD_ARGUMENT_HELP_MESSAGE = 'Block identifier to get a list of batches fr
 BATCH_REVERSE_ARGUMENT_HELP_MESSAGE = 'Parameter to reverse result.'
 BATCH_STATUS_IDENTIFIER_ARGUMENT_HELP_MESSAGE = 'Identifier to get a batch status by.'
 BATCH_ID_ARGUMENT_HELP_MESSAGE = 'Identifier to get a batch by.'
+BATCH_IDENTIFIERS_ONLY_ARGUMENT_HELP_MESSAGE = 'The flag to get a list of batches\' identifiers.'

--- a/cli/batch/interfaces.py
+++ b/cli/batch/interfaces.py
@@ -41,3 +41,19 @@ class BatchInterface:
             reverse (bool, optional): parameter to reverse result.
         """
         pass
+
+    def get_list_ids(self, ids, start, limit, head, reverse):
+        """
+        Get a list of batches' identifiers.
+
+        A list of batch identifiers could be filtered by batch identifiers, start identifier, limit, head identifier,
+        reverse.
+
+        Arguments:
+            ids (list, optional): identifiers to get a list of batches by.
+            start (string, optional): batch identifier to get a list of batches starting from.
+            limit (int, optional): maximum amount of batches to return.
+            head (string, optional): block identifier to get a list of batches from.
+            reverse (bool, optional): parameter to reverse result.
+        """
+        pass

--- a/cli/batch/service.py
+++ b/cli/batch/service.py
@@ -93,3 +93,27 @@ class Batch:
             return None, str(error)
 
         return batches.get('data'), None
+
+    def get_list_ids(self, ids, start, limit, head, reverse):
+        """
+        Get a list of batches' identifiers.
+
+        Arguments:
+            ids (list, optional): identifiers to get a list of batches by.
+            start (string, optional): batch identifier to get a list of batches starting from.
+            limit (int, optional): maximum amount of batches to return.
+            head (string, optional): block identifier to get a list of batches from.
+            reverse (bool, optional): parameter to reverse result.
+        """
+        batches, errors = self.get_list(ids=ids, start=start, head=head, limit=limit, reverse=reverse)
+
+        if errors is not None:
+            return None, errors
+
+        batch_identifiers = []
+
+        for batch in batches:
+            batch_identifier = batch.get('header_signature')
+            batch_identifiers.append(batch_identifier)
+
+        return batch_identifiers, None

--- a/tests/batch/test_get_list_batches.py
+++ b/tests/batch/test_get_list_batches.py
@@ -11,6 +11,7 @@ from cli.constants import (
     BLOCK_IDENTIFIER_REGEXP,
     DEV_BRANCH_NODE_IP_ADDRESS_FOR_TESTING,
     FAILED_EXIT_FROM_COMMAND_CODE,
+    HEADER_SIGNATURE_REGEXP,
     PASSED_EXIT_FROM_COMMAND_CODE,
 )
 from cli.entrypoint import cli
@@ -84,6 +85,28 @@ def test_get_list_batches_with_ids():
 
         assert re.match(pattern=BLOCK_IDENTIFIER_REGEXP, string=block_identifier) is not None
         assert block_identifier in COMMITTED_BATCH_IDENTIFIERS
+
+
+def test_get_batches_identifiers():
+    """
+    Case: get a list of batches' identifiers.
+    Expect: a list of batches' identifiers is returned.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'batch',
+        'get-list',
+        '--ids-only',
+        '--node-url',
+        DEV_BRANCH_NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    batches = json.loads(result.output).get('result')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+
+    for batch_identifier in batches:
+        assert re.match(pattern=HEADER_SIGNATURE_REGEXP, string=batch_identifier) is not None
 
 
 def test_get_list_batches_with_invalid_ids():


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1414

### Description
Get a list of batch identifiers — ``remme batch get-list --ids-only``:

| Arguments   | Type   |  Required | Description                                             |
| :--------:  | :----: | :-------: | -----------------------------------------------------   |
| ids         | String |  No       | Identifiers to get a list of batches by.                |
| start       | String |  No       | Batch identifier to get a list of batches starting from.|
| limit       | Integer|  No       | Maximum amount of batches to return.                    |
| head        | String |  No       | Block identifier to get a list of batches from.         |
| reverse     | Bool   |  No       | Parameter to reverse result.                            |
| ids-only    | Bool   |  No       | Command flag to return batch identifiers only.          |
| node-url    | String |  No       | Node URL to apply a command to.                         |

$ remme batch get-list \
      --limit=2 \
      --ids-only \
      --node-url=node-6-testnet.remme.io
{
    "result": [
        "e4d5089f2ef15d20818b937e1fcf05e04b70ef6860069b31f441124e8d53243f35c265190520b25da07c3eb47354e6e145c6e52229683829dba6b0f185b3b6ca",
        "df5e555f9e014e6d6d08b25f82698a1cf06eff4a11e941c0284f210d7b1535d3542f37dd5546d2fc08d51a866910317987933107c1cd2ef14860d0317f039501"
    ]
}
