### PR TITLE
Implement opening the node CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,17 @@ $ remme node get-info --node-url=node-27-testnet.remme.io
 }
 ```
 
+Open the node to participate in the network (executable only on the machine which runs the node) — ``remme node open``:
+
+```bash
+$ remme node open
+{
+    "result": {
+        "batch_id": "b877a10ddc0ef7f28b0b4a075cbab580b5f7be4dc4063e282a87ce812105316569ccba6c554176c36174bb62025181dc7bb9d83cba57d90dd27c04c043261c9c"
+    }
+}
+```
+
 Get the initial stake of the node — ``remme node get-initial-stake``:
 
 | Arguments | Type   | Required | Description                     |

--- a/cli/node/interfaces.py
+++ b/cli/node/interfaces.py
@@ -31,3 +31,9 @@ class NodeInterface:
         Get the initial stake of the node.
         """
         pass
+
+    def open(self):
+        """
+        Open the node to participate in the network.
+        """
+        pass

--- a/cli/node/service.py
+++ b/cli/node/service.py
@@ -78,3 +78,17 @@ class Node:
             return None, str(error)
 
         return node_initial_stake, None
+
+    def open(self):
+        """
+        Open the node to participate in the network.
+        """
+        try:
+            open_node = loop.run_until_complete(self.service.node_management.open_node())
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'batch_id': open_node.batch_id,
+        }, None

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -44,7 +44,7 @@ def print_errors(errors):
     Print error messages to the terminal.
 
     Arguments:
-        errors (dict): dictionary with error messages.
+        errors (string or dict): dictionary with error messages.
 
     References:
         - https://click.palletsprojects.com/en/7.x/utils/#ansi-colors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,20 @@ class NodeAccountInformation:
         }
 
 
+class OpenNodeTransaction:
+    """
+    Impose open node transaction's data transfer object.
+    """
+
+    @property
+    def batch_id(self):
+        """
+        Get batch identifier of the open node transaction.
+        """
+        return '37809770b004dcbc7dae116fd9f17428255ddddee3304c9b3d14609d2792e78f' \
+               '08f5308af03fd4aa18ff1d868f043b12dd7b0a792e141f000a2505acd4b7a956'
+
+
 @pytest.fixture()
 def sent_transaction():
     """
@@ -290,3 +304,11 @@ def node_account_information():
     Get node account information fixture.
     """
     return NodeAccountInformation()
+
+
+@pytest.fixture()
+def open_node_transaction():
+    """
+    Get the open node transaction fixture.
+    """
+    return OpenNodeTransaction()

--- a/tests/node/test_open.py
+++ b/tests/node/test_open.py
@@ -1,0 +1,32 @@
+"""
+Provide tests for command line interface's node open command.
+"""
+import json
+
+from click.testing import CliRunner
+
+from cli.constants import PASSED_EXIT_FROM_COMMAND_CODE
+from cli.entrypoint import cli
+
+
+def test_open_node(mocker, open_node_transaction):
+    """
+    Case: open the node.
+    Expect: opening node transaction's batch identifier is returned.
+    """
+    mock_mock_get_node_private_key = mocker.patch('cli.config.NodePrivateKey.get')
+    mock_mock_get_node_private_key.return_value = '42dada12f863528bd456785d8c544154db6ec9455be2c123d91b687df3697314'
+
+    mock_open_masternode = mocker.patch('cli.node.service.loop.run_until_complete')
+    mock_open_masternode.return_value = open_node_transaction
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node',
+        'open',
+    ])
+
+    node_open_transaction_identifier = json.loads(result.output).get('result').get('batch_id')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert open_node_transaction.batch_id == node_open_transaction_identifier


### PR DESCRIPTION
### Description

Open the node to participate in the network (executable only on the machine which runs the node) command implementation.

Example of the usage:

```bash
$ remme node open
{
    "result": {
        "batch_id": "b877a10ddc0ef7f28b0b4a075cbab580b5f7be4dc4063e282a87ce812105316569ccba6c554176c36174bb62025181dc7bb9d83cba57d90dd27c04c043261c9c"
    }
}
```

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with `Remme-core` — https://github.com/Remmeauth/remme-client-python
