### PR TITLE
Implement opening the masternode CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     * [Atomic Swap](#atomic-swap)
     * [Batch](#batch)
     * [Node](#node)
+    * [Masternode](#masternode)
     * [Public key](#public-key)
     * [State](#state)
     * [Transaction](#transaction)
@@ -685,6 +686,23 @@ Get the initial stake of the node — ``remme node get-initial-stake``:
 $ remme node get-initial-stake --node-url=node-27-testnet.remme.io
 {
     "result": 250000
+}
+```
+
+### Masternode
+
+Open the masternode (executable only on the machine which runs the node) — ``remme masternode open``:
+
+| Arguments | Type      |  Required  | Description                                                 |
+| :-------: | :-------: | :--------: | ----------------------------------------------------------- |
+| amount    | Integer   |  Yes       | Starting amount of tokens to put to the masternode account. |
+
+```bash
+$ remme masternode open --amount=300000
+{
+    "result": {
+        "batch_id": "b877a10ddc0ef7f28b0b4a075cbab580b5f7be4dc4063e282a87ce812105316569ccba6c554176c36174bb62025181dc7bb9d83cba57d90dd27c04c043261c9c"
+    }
 }
 ```
 

--- a/cli/entrypoint.py
+++ b/cli/entrypoint.py
@@ -7,6 +7,7 @@ from cli.account.cli import account_commands
 from cli.atomic_swap.cli import atomic_swap_commands
 from cli.batch.cli import batch_commands
 from cli.block.cli import block_commands
+from cli.masternode.cli import masternode_commands
 from cli.node.cli import node_commands
 from cli.node_account.cli import node_account_commands
 from cli.public_key.cli import public_key_commands
@@ -29,6 +30,7 @@ cli.add_command(account_commands)
 cli.add_command(atomic_swap_commands)
 cli.add_command(batch_commands)
 cli.add_command(block_commands)
+cli.add_command(masternode_commands)
 cli.add_command(node_commands)
 cli.add_command(node_account_commands)
 cli.add_command(public_key_commands)

--- a/cli/masternode/cli.py
+++ b/cli/masternode/cli.py
@@ -1,0 +1,64 @@
+"""
+Provide implementation of the command line interface's masternode commands.
+"""
+import sys
+
+import click
+from remme import Remme
+from remme.models.account.account_type import AccountType
+
+from cli.config import NodePrivateKey
+from cli.constants import FAILED_EXIT_FROM_COMMAND_CODE
+from cli.errors import NotSupportedOsToGetNodePrivateKeyError
+from cli.masternode.forms import OpenMasternodeForm
+from cli.masternode.help import STARTING_AMOUNT_ARGUMENT_HELP_MESSAGE
+from cli.masternode.service import Masternode
+from cli.utils import (
+    print_errors,
+    print_result,
+)
+
+
+@click.group('masternode', chain=True)
+def masternode_commands():
+    """
+    Provide commands for working with masternode.
+    """
+    pass
+
+
+@click.option('--amount', type=int, required=True, help=STARTING_AMOUNT_ARGUMENT_HELP_MESSAGE)
+@masternode_commands.command('open')
+def open(amount):
+    """
+    Open the masternode with starting amount.
+    """
+    arguments, errors = OpenMasternodeForm().load({
+        'amount': amount,
+    })
+
+    if errors:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    amount = arguments.get('amount')
+
+    try:
+        node_private_key = NodePrivateKey().get()
+
+    except (NotSupportedOsToGetNodePrivateKeyError, FileNotFoundError) as error:
+        print_errors(errors=str(error))
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    remme = Remme(
+        account_config={'private_key_hex': node_private_key, 'account_type': AccountType.NODE},
+        network_config={'node_address': 'localhost' + ':8080'},
+    )
+
+    result, errors = Masternode(service=remme).open(amount=amount)
+
+    if errors is not None:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    print_result(result=result)

--- a/cli/masternode/forms.py
+++ b/cli/masternode/forms.py
@@ -1,0 +1,22 @@
+"""
+Provide forms for command line interface's masternode commands.
+"""
+from marshmallow import (
+    Schema,
+    fields,
+    validate,
+)
+
+
+class OpenMasternodeForm(Schema):
+    """
+    Open the masternode with starting amount form.
+    """
+
+    amount = fields.Integer(
+        strict=True,
+        required=True,
+        validate=[
+            validate.Range(min=1, error='Amount must be greater than 0.'),
+        ],
+    )

--- a/cli/masternode/help.py
+++ b/cli/masternode/help.py
@@ -1,0 +1,4 @@
+"""
+Provide help messages for command line interface's masternode commands.
+"""
+STARTING_AMOUNT_ARGUMENT_HELP_MESSAGE = 'Starting amount of tokens to put to the masternode account.'

--- a/cli/masternode/interfaces.py
+++ b/cli/masternode/interfaces.py
@@ -1,0 +1,15 @@
+"""
+Provide implementation of the masternode interfaces.
+"""
+
+
+class MasternodeInterface:
+    """
+    Implements masternode interface.
+    """
+
+    def open(self, amount):
+        """
+        Open the masternode with starting amount.
+        """
+        pass

--- a/cli/masternode/service.py
+++ b/cli/masternode/service.py
@@ -1,0 +1,42 @@
+"""
+Provide implementation of the masternode.
+"""
+import asyncio
+
+from accessify import implements
+
+from cli.masternode.interfaces import MasternodeInterface
+
+loop = asyncio.get_event_loop()
+
+
+@implements(MasternodeInterface)
+class Masternode:
+    """
+    Implements masternode.
+    """
+
+    def __init__(self, service):
+        """
+        Constructor.
+
+        Arguments:
+            service: object to interact with Remme core API.
+        """
+        self.service = service
+
+    def open(self, amount):
+        """
+        Open the masternode with starting amount.
+        """
+        try:
+            open_masternode = loop.run_until_complete(
+                self.service.node_management.open_master_node(amount=amount),
+            )
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'batch_id': open_masternode.batch_id,
+        }, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,6 +258,20 @@ class OpenNodeTransaction:
                '08f5308af03fd4aa18ff1d868f043b12dd7b0a792e141f000a2505acd4b7a956'
 
 
+class OpenMasternodeTransaction:
+    """
+    Impose open masternode transaction's data transfer object.
+    """
+
+    @property
+    def batch_id(self):
+        """
+        Get batch identifier of the open masternode transaction.
+        """
+        return '37809770b004dcbc7dae116fd9f17428255ddddee3304c9b3d14609d2792e78f' \
+               '08f5308af03fd4aa18ff1d868f043b12dd7b0a792e141f000a2505acd4b7a956'
+
+
 @pytest.fixture()
 def sent_transaction():
     """
@@ -312,3 +326,11 @@ def open_node_transaction():
     Get the open node transaction fixture.
     """
     return OpenNodeTransaction()
+
+
+@pytest.fixture()
+def open_masternode_transaction():
+    """
+    Get the open masternode transaction fixture.
+    """
+    return OpenMasternodeTransaction()

--- a/tests/masternode/test_open_.py
+++ b/tests/masternode/test_open_.py
@@ -1,0 +1,34 @@
+"""
+Provide tests for command line interface's masternode open command.
+"""
+import json
+
+from click.testing import CliRunner
+
+from cli.constants import PASSED_EXIT_FROM_COMMAND_CODE
+from cli.entrypoint import cli
+
+
+def test_open_node(mocker, open_masternode_transaction):
+    """
+    Case: open the masternode.
+    Expect: opening masternode transaction's batch identifier is returned.
+    """
+    mock_mock_get_node_private_key = mocker.patch('cli.config.NodePrivateKey.get')
+    mock_mock_get_node_private_key.return_value = '42dada12f863528bd456785d8c544154db6ec9455be2c123d91b687df3697314'
+
+    mock_open_masternode = mocker.patch('cli.node.service.loop.run_until_complete')
+    mock_open_masternode.return_value = open_masternode_transaction
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'masternode',
+        'open',
+        '--amount',
+        300000,
+    ])
+
+    node_open_transaction_identifier = json.loads(result.output).get('result').get('batch_id')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert open_masternode_transaction.batch_id == node_open_transaction_identifier


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1316

### Description

Open the masternode command line interface's command implementation.

| Arguments  | Type     |  Required  | Description                                         |
| :--------: | :------: | :--------: | --------------------------------------------------- |
| amount    | Integer   |  Yes       | Starting amount of tokens to put to the masternode account.         |

Example of the usage:

```bash
$ remme masternode open --amount=300000
{
    "result": {
        "batch_id": "5fd4e479c3ae518d8c6e73950c0ff028042985adfd3a64a89a0ffc351567a2851866bde1e4cee4818da63fad3d7299bb35b8a78237dbc698eebd36027016e26a"
    }
}
```

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with `Remme-core` — https://github.com/Remmeauth/remme-client-python
