### PR TITLE
Implement the transfer of tokens from the node account address

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ $ remme account transfer-tokens \
 }
 ```
 
-### Node Account
+### Node account
 
 Get information about the node account by its address — ``remme node-account get``:
 
@@ -232,6 +232,28 @@ $ remme node-account get \
             },
         ],
     },
+}
+```
+
+Transfer tokens to address — ``remme node-account transfer-tokens``:
+
+| Arguments   | Type    | Required | Description                                    |
+| :---------: | :-----: | :------: | ---------------------------------------------- |
+| private-key | String  | Yes      | Account's private key to transfer tokens from. |
+| address-to  | String  | Yes      | Node account address to transfer tokens to.    |
+| amount      | Integer | Yes      | Amount to transfer.                            |
+| node-url    | String  | No       | Node URL to apply a command to.                |
+
+```bash
+$ remme node-account transfer-tokens \
+      --private-key=7ae575740dcdae8e704ff461ab89ad42505e06abbbae8ea68e18387e537b7462 \
+      --address-to=1168292465adcaffeea284f89330dcc013533c8c285089b75466a958733f4f3fc9174d \
+      --amount=100 \
+      --node-url=node-genesis-testnet.remme.io
+{
+    "result": {
+        "batch_id": "045c2b7c43a7ca7c3dc60e92714c03265572a726d1fae631c39a404eaf97770e3f6a7a8c35c86f6361afb2e4f12b4a17d71a66a19158b62f30531ab32b62f06f"
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Transfer tokens to address — ``remme node-account transfer-tokens``:
 | Arguments   | Type    | Required | Description                                    |
 | :---------: | :-----: | :------: | ---------------------------------------------- |
 | private-key | String  | Yes      | Account's private key to transfer tokens from. |
-| address-to  | String  | Yes      | Node account address to transfer tokens to.    |
+| address-to  | String  | Yes      | Account address to transfer tokens to.         |
 | amount      | Integer | Yes      | Amount to transfer.                            |
 | node-url    | String  | No       | Node URL to apply a command to.                |
 

--- a/cli/account/cli.py
+++ b/cli/account/cli.py
@@ -6,10 +6,7 @@ import sys
 import click
 from remme import Remme
 
-from cli.account.forms import (
-    GetAccountBalanceForm,
-    TransferTokensForm,
-)
+from cli.account.forms import GetAccountBalanceForm
 from cli.account.help import (
     ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE,
     ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE,
@@ -21,6 +18,7 @@ from cli.constants import (
     FAILED_EXIT_FROM_COMMAND_CODE,
     NODE_URL_ARGUMENT_HELP_MESSAGE,
 )
+from cli.generic.forms.forms import TransferTokensForm
 from cli.utils import (
     default_node_url,
     print_errors,

--- a/cli/account/forms.py
+++ b/cli/account/forms.py
@@ -1,16 +1,11 @@
 """
 Provide forms for command line interface's account commands.
 """
-from marshmallow import (
-    Schema,
-    fields,
-    validate,
-)
+from marshmallow import Schema
 
 from cli.generic.forms.fields import (
     AccountAddressField,
     NodeUrlField,
-    PrivateKeyField,
 )
 
 
@@ -20,21 +15,4 @@ class GetAccountBalanceForm(Schema):
     """
 
     address = AccountAddressField(required=True)
-    node_url = NodeUrlField(required=True)
-
-
-class TransferTokensForm(Schema):
-    """
-    Transfer tokens to address form.
-    """
-
-    private_key = PrivateKeyField(required=True)
-    address_to = AccountAddressField(required=True)
-    amount = fields.Integer(
-        strict=True,
-        required=True,
-        validate=[
-            validate.Range(min=1, error='Amount must be greater than 0.'),
-        ],
-    )
     node_url = NodeUrlField(required=True)

--- a/cli/generic/forms/forms.py
+++ b/cli/generic/forms/forms.py
@@ -1,0 +1,31 @@
+"""
+Provide implementation of the generic forms.
+"""
+from marshmallow import (
+    Schema,
+    fields,
+    validate,
+)
+
+from cli.generic.forms.fields import (
+    AccountAddressField,
+    NodeUrlField,
+    PrivateKeyField,
+)
+
+
+class TransferTokensForm(Schema):
+    """
+    Transfer tokens to address form.
+    """
+
+    private_key = PrivateKeyField(required=True)
+    address_to = AccountAddressField(required=True)
+    amount = fields.Integer(
+        strict=True,
+        required=True,
+        validate=[
+            validate.Range(min=1, error='Amount must be greater than 0.'),
+        ],
+    )
+    node_url = NodeUrlField(required=True)

--- a/cli/node_account/cli.py
+++ b/cli/node_account/cli.py
@@ -5,13 +5,22 @@ import sys
 
 import click
 from remme import Remme
+from remme.models.account.account_type import AccountType
 
 from cli.constants import (
     FAILED_EXIT_FROM_COMMAND_CODE,
     NODE_URL_ARGUMENT_HELP_MESSAGE,
 )
-from cli.node_account.forms import GetNodeAccountInformationForm
-from cli.node_account.help import NODE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE
+from cli.node_account.forms import (
+    GetNodeAccountInformationForm,
+    TransferTokensForm,
+)
+from cli.node_account.help import (
+    AMOUNT_ARGUMENT_HELP_MESSAGE,
+    NODE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE,
+    NODE_ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE,
+    PRIVATE_KEY_ARGUMENT_HELP_MESSAGE,
+)
 from cli.node_account.service import NodeAccount
 from cli.utils import (
     default_node_url,
@@ -52,6 +61,45 @@ def get(address, node_url):
     )
 
     result, errors = NodeAccount(service=remme).get(address=node_account_address)
+
+    if errors is not None:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    print_result(result=result)
+
+
+@click.option('--private-key', type=str, required=True, help=PRIVATE_KEY_ARGUMENT_HELP_MESSAGE)
+@click.option('--address-to', type=str, required=True, help=NODE_ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE)
+@click.option('--amount', type=int, required=True, help=AMOUNT_ARGUMENT_HELP_MESSAGE)
+@click.option('--node-url', type=str, required=False, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
+@node_account_commands.command('transfer-tokens')
+def transfer_tokens(private_key, address_to, amount, node_url):
+    """
+    Transfer tokens to address.
+    """
+    arguments, errors = TransferTokensForm().load({
+        'private_key': private_key,
+        'address_to': address_to,
+        'amount': amount,
+        'node_url': node_url,
+    })
+
+    if errors:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    private_key = arguments.get('private_key')
+    address_to = arguments.get('address_to')
+    amount = arguments.get('amount')
+    node_url = arguments.get('node_url')
+
+    remme = Remme(
+        account_config={'private_key_hex': private_key, 'account_type': AccountType.NODE},
+        network_config={'node_address': str(node_url) + ':8080'},
+    )
+
+    result, errors = NodeAccount(service=remme).transfer_tokens(address_to=address_to, amount=amount)
 
     if errors is not None:
         print_errors(errors=errors)

--- a/cli/node_account/cli.py
+++ b/cli/node_account/cli.py
@@ -11,14 +11,12 @@ from cli.constants import (
     FAILED_EXIT_FROM_COMMAND_CODE,
     NODE_URL_ARGUMENT_HELP_MESSAGE,
 )
-from cli.node_account.forms import (
-    GetNodeAccountInformationForm,
-    TransferTokensForm,
-)
+from cli.generic.forms.forms import TransferTokensForm
+from cli.node_account.forms import GetNodeAccountInformationForm
 from cli.node_account.help import (
+    ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE,
     AMOUNT_ARGUMENT_HELP_MESSAGE,
     NODE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE,
-    NODE_ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE,
     PRIVATE_KEY_ARGUMENT_HELP_MESSAGE,
 )
 from cli.node_account.service import NodeAccount
@@ -70,7 +68,7 @@ def get(address, node_url):
 
 
 @click.option('--private-key', type=str, required=True, help=PRIVATE_KEY_ARGUMENT_HELP_MESSAGE)
-@click.option('--address-to', type=str, required=True, help=NODE_ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE)
+@click.option('--address-to', type=str, required=True, help=ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE)
 @click.option('--amount', type=int, required=True, help=AMOUNT_ARGUMENT_HELP_MESSAGE)
 @click.option('--node-url', type=str, required=False, help=NODE_URL_ARGUMENT_HELP_MESSAGE, default=default_node_url())
 @node_account_commands.command('transfer-tokens')

--- a/cli/node_account/forms.py
+++ b/cli/node_account/forms.py
@@ -1,11 +1,16 @@
 """
 Provide forms for command line interface's node account commands.
 """
-from marshmallow import Schema
+from marshmallow import (
+    Schema,
+    fields,
+    validate,
+)
 
 from cli.generic.forms.fields import (
     AccountAddressField,
     NodeUrlField,
+    PrivateKeyField,
 )
 
 
@@ -15,4 +20,21 @@ class GetNodeAccountInformationForm(Schema):
     """
 
     address = AccountAddressField(required=True)
+    node_url = NodeUrlField(required=True)
+
+
+class TransferTokensForm(Schema):
+    """
+    Transfer tokens to address form.
+    """
+
+    private_key = PrivateKeyField(required=True)
+    address_to = AccountAddressField(required=True)
+    amount = fields.Integer(
+        strict=True,
+        required=True,
+        validate=[
+            validate.Range(min=1, error='Amount must be greater than 0.'),
+        ],
+    )
     node_url = NodeUrlField(required=True)

--- a/cli/node_account/forms.py
+++ b/cli/node_account/forms.py
@@ -1,16 +1,11 @@
 """
 Provide forms for command line interface's node account commands.
 """
-from marshmallow import (
-    Schema,
-    fields,
-    validate,
-)
+from marshmallow import Schema
 
 from cli.generic.forms.fields import (
     AccountAddressField,
     NodeUrlField,
-    PrivateKeyField,
 )
 
 
@@ -20,21 +15,4 @@ class GetNodeAccountInformationForm(Schema):
     """
 
     address = AccountAddressField(required=True)
-    node_url = NodeUrlField(required=True)
-
-
-class TransferTokensForm(Schema):
-    """
-    Transfer tokens to address form.
-    """
-
-    private_key = PrivateKeyField(required=True)
-    address_to = AccountAddressField(required=True)
-    amount = fields.Integer(
-        strict=True,
-        required=True,
-        validate=[
-            validate.Range(min=1, error='Amount must be greater than 0.'),
-        ],
-    )
     node_url = NodeUrlField(required=True)

--- a/cli/node_account/help.py
+++ b/cli/node_account/help.py
@@ -2,6 +2,6 @@
 Provide help messages for command line interface's node account commands.
 """
 NODE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Node account address to get information about node account by.'
-NODE_ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE = 'Node account address to transfer tokens to.'
+ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE = 'Account address to transfer tokens to.'
 AMOUNT_ARGUMENT_HELP_MESSAGE = 'Amount to transfer.'
-PRIVATE_KEY_ARGUMENT_HELP_MESSAGE = 'Node account\'s private key to transfer tokens from.'
+PRIVATE_KEY_ARGUMENT_HELP_MESSAGE = 'Account\'s private key to transfer tokens from.'

--- a/cli/node_account/help.py
+++ b/cli/node_account/help.py
@@ -2,3 +2,6 @@
 Provide help messages for command line interface's node account commands.
 """
 NODE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE = 'Node account address to get information about node account by.'
+NODE_ACCOUNT_ADDRESS_TO_ARGUMENT_HELP_MESSAGE = 'Node account address to transfer tokens to.'
+AMOUNT_ARGUMENT_HELP_MESSAGE = 'Amount to transfer.'
+PRIVATE_KEY_ARGUMENT_HELP_MESSAGE = 'Node account\'s private key to transfer tokens from.'

--- a/cli/node_account/interfaces.py
+++ b/cli/node_account/interfaces.py
@@ -16,3 +16,9 @@ class NodeAccountInterface:
             address (str, required): node account address to get information about node account by.
         """
         pass
+
+    def transfer_tokens(self, address_to, amount):
+        """
+        Transfer tokens to address.
+        """
+        pass

--- a/cli/node_account/service.py
+++ b/cli/node_account/service.py
@@ -45,3 +45,17 @@ class NodeAccount:
             return None, str(error)
 
         return node_account_information.node_account_response, None
+
+    def transfer_tokens(self, address_to, amount):
+        """
+        Transfer tokens to address.
+        """
+        try:
+            transaction = loop.run_until_complete(self.service.token.transfer(address_to=address_to, amount=amount))
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'batch_id': transaction.batch_id,
+        }, None

--- a/tests/node_account/test_transfer_tokens_.py
+++ b/tests/node_account/test_transfer_tokens_.py
@@ -1,0 +1,289 @@
+"""
+Provide tests for command line interface's node account transfer tokens command.
+"""
+import json
+import re
+
+import pytest
+from click.testing import CliRunner
+
+from cli.constants import (
+    BATCH_IDENTIFIER_REGEXP,
+    DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+    DEV_CONSENSUS_GENESIS_NODE_IP_ADDRESS_FOR_TESTING,
+    FAILED_EXIT_FROM_COMMAND_CODE,
+    INCORRECT_ENTERED_COMMAND_CODE,
+    PASSED_EXIT_FROM_COMMAND_CODE,
+)
+from cli.entrypoint import cli
+from cli.utils import dict_to_pretty_json
+
+NODE_PRIVATE_KEY_WITH_MONEY = '7ae575740dcdae8e704ff461ab89ad42505e06abbbae8ea68e18387e537b7462'
+
+
+def test_transfer_tokens():
+    """
+    Case: transfer tokens to address.
+    Expect: batch identifier is returned.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        '10',
+        '--node-url',
+        DEV_CONSENSUS_GENESIS_NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    batch_id = json.loads(result.output).get('result').get('batch_id')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert re.match(pattern=BATCH_IDENTIFIER_REGEXP, string=batch_id) is not None
+
+
+def test_transfer_tokens_invalid_private_key():
+    """
+    Case: transfer tokens to address with an invalid private key.
+    Expect: the following private key is invalid error message.
+    """
+    invalid_private_key = 'b03e31d2f310305eab249133b53b5fb327'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        invalid_private_key,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        '10',
+        '--node-url',
+        DEV_CONSENSUS_GENESIS_NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    expected_error = {
+        'errors': {
+            'private_key': [
+                f'The following private key `{invalid_private_key}` is invalid.',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+def test_transfer_tokens_invalid_address_to():
+    """
+    Case: transfer tokens to an invalid address.
+    Expect: the following address to is invalid error message.
+    """
+    invalid_address_to = '1120076ecf036e857f42129b5830'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        invalid_address_to,
+        '--amount',
+        '10',
+        '--node-url',
+        DEV_CONSENSUS_GENESIS_NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    expected_error = {
+        'errors': {
+            'address_to': [
+                f'The following address `{invalid_address_to}` is invalid.',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+def test_transfer_tokens_invalid_amount():
+    """
+    Case: transfer tokens to address with the invalid amount.
+    Expect: amount is not a valid integer error message.
+    """
+    invalid_amount = 'je682'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        invalid_amount,
+        '--node-url',
+        DEV_CONSENSUS_GENESIS_NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    assert INCORRECT_ENTERED_COMMAND_CODE == result.exit_code
+    assert f'{invalid_amount} is not a valid integer' in result.output
+
+
+@pytest.mark.parametrize('insufficient_amount', [-1, 0])
+def test_transfer_tokens_with_insufficient_amount(insufficient_amount):
+    """
+    Case: transfer tokens to address with the insufficient amount.
+    Expect: amount must be greater than 0 error message.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        insufficient_amount,
+        '--node-url',
+        DEV_CONSENSUS_GENESIS_NODE_IP_ADDRESS_FOR_TESTING,
+    ])
+
+    expected_error = {
+        'errors': {
+            'amount': [
+                f'Amount must be greater than 0.',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+def test_transfer_tokens_without_node_url(mocker, sent_transaction):
+    """
+    Case: transfer tokens to address without passing node URL.
+    Expect: batch identifier is returned from a node on localhost.
+    """
+    mock_node_account_transfer_tokens = mocker.patch('cli.node_account.service.loop.run_until_complete')
+    mock_node_account_transfer_tokens.return_value = sent_transaction
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        '10',
+    ])
+
+    batch_id = json.loads(result.output).get('result').get('batch_id')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert re.match(pattern=BATCH_IDENTIFIER_REGEXP, string=batch_id) is not None
+
+
+def test_transfer_tokens_invalid_node_url():
+    """
+    Case: transfer tokens to address by passing an invalid node URL.
+    Expect: the following node URL is invalid error message.
+    """
+    invalid_node_url = 'domainwithoutextention'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        '10',
+        '--node-url',
+        invalid_node_url,
+    ])
+
+    expected_error = {
+        'errors': {
+            'node_url': [
+                f'The following node URL `{invalid_node_url}` is invalid.',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+def test_transfer_tokens_non_existing_node_url():
+    """
+    Case: transfer tokens to address by passing the non-existing node URL.
+    Expect: check if node running at the URL error message.
+    """
+    non_existing_node_url = 'non-existing-node.com'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        '10',
+        '--node-url',
+        non_existing_node_url,
+    ])
+
+    expected_error = {
+        'errors': f'Please check if your node running at http://{non_existing_node_url}:8080.',
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output
+
+
+@pytest.mark.parametrize('node_url_with_protocol', ['http://masternode.com', 'https://masternode.com'])
+def test_transfer_tokens_node_url_with_protocol(node_url_with_protocol):
+    """
+    Case: transfer tokens to address by passing node URL with an explicit protocol.
+    Expect: the following node URL contains a protocol error message.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens',
+        '--private-key',
+        NODE_PRIVATE_KEY_WITH_MONEY,
+        '--address-to',
+        DEV_CONSENSUS_GENESIS_NODE_ACCOUNT_ADDRESS,
+        '--amount',
+        '10',
+        '--node-url',
+        node_url_with_protocol,
+    ])
+
+    expected_error = {
+        'errors': {
+            'node_url': [
+                f'Pass the following node URL `{node_url_with_protocol}` without protocol (http, https, etc.).',
+            ],
+        },
+    }
+
+    assert FAILED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert dict_to_pretty_json(expected_error) in result.output


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1318

### Description

Transfer tokens from the node account address command line interface's command implementation.

| Arguments   | Type    | Required | Description                                    |
| :---------: | :-----: | :------: | ---------------------------------------------- |
| private-key | String  | Yes      | Account's private key to transfer tokens from. |
| address-to  | String  | Yes      | Node account address to transfer tokens to.    |
| amount      | Integer | Yes      | Amount to transfer.                            |
| node-url    | String  | No       | Node URL to apply a command to.                |

Example of the usage:

```bash
$ remme node-account transfer-tokens \
      --private-key=7ae575740dcdae8e704ff461ab89ad42505e06abbbae8ea68e18387e537b7462 \
      --address-to=1168292465adcaffeea284f89330dcc013533c8c285089b75466a958733f4f3fc9174d \
      --amount=100 \
      --node-url=node-genesis-testnet.remme.io
{
    "result": {
        "batch_id": "045c2b7c43a7ca7c3dc60e92714c03265572a726d1fae631c39a404eaf97770e3f6a7a8c35c86f6361afb2e4f12b4a17d71a66a19158b62f30531ab32b62f06f"
    }
}
```

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with `Remme-core` — https://github.com/Remmeauth/remme-client-python