### PR TITLE
Implement close the masternode CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,17 @@ $ remme masternode open --amount=300000
 }
 ```
 
+Close the masternode (executable only on the machine which runs the node) — ``remme masternode close``:
+
+```bash
+$ remme masternode close
+{
+    "result": {
+        "batch_id": "ae0ad8d5379beb28211cdc3f4d70a7ef66852eb815241cb201425897fc470e727c34e67ea77525ac696633afd27cca88227df52493889edcbb6fb840b4c93326"
+    }
+}
+```
+
 ### Public key
 
 Get a list of the addresses of the public keys by account address — ``remme public-key get-list``:

--- a/cli/masternode/cli.py
+++ b/cli/masternode/cli.py
@@ -62,3 +62,29 @@ def open(amount):
         sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
 
     print_result(result=result)
+
+
+@masternode_commands.command('close')
+def close():
+    """
+    Close the masternode.
+    """
+    try:
+        node_private_key = NodePrivateKey().get()
+
+    except (NotSupportedOsToGetNodePrivateKeyError, FileNotFoundError) as error:
+        print_errors(errors=str(error))
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    remme = Remme(
+        account_config={'private_key_hex': node_private_key, 'account_type': AccountType.NODE},
+        network_config={'node_address': 'localhost' + ':8080'},
+    )
+
+    result, errors = Masternode(service=remme).close()
+
+    if errors is not None:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    print_result(result=result)

--- a/cli/masternode/interfaces.py
+++ b/cli/masternode/interfaces.py
@@ -13,3 +13,9 @@ class MasternodeInterface:
         Open the masternode with starting amount.
         """
         pass
+
+    def close(self):
+        """
+        Close the masternode.
+        """
+        pass

--- a/cli/masternode/service.py
+++ b/cli/masternode/service.py
@@ -40,3 +40,19 @@ class Masternode:
         return {
             'batch_id': open_masternode.batch_id,
         }, None
+
+    def close(self):
+        """
+        Close the masternode.
+        """
+        try:
+            close_masternode = loop.run_until_complete(
+                self.service.node_management.close_master_node(),
+            )
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'batch_id': close_masternode.batch_id,
+        }, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,20 @@ class OpenMasternodeTransaction:
                '08f5308af03fd4aa18ff1d868f043b12dd7b0a792e141f000a2505acd4b7a956'
 
 
+class CloseMasternodeTransaction:
+    """
+    Impose close masternode transaction's data transfer object.
+    """
+
+    @property
+    def batch_id(self):
+        """
+        Get batch identifier of the close masternode transaction.
+        """
+        return 'ae0ad8d5379beb28211cdc3f4d70a7ef66852eb815241cb201425897fc470e72' \
+               '7c34e67ea77525ac696633afd27cca88227df52493889edcbb6fb840b4c93326'
+
+
 @pytest.fixture()
 def sent_transaction():
     """
@@ -334,3 +348,11 @@ def open_masternode_transaction():
     Get the open masternode transaction fixture.
     """
     return OpenMasternodeTransaction()
+
+
+@pytest.fixture()
+def close_masternode_transaction():
+    """
+    Get the close masternode transaction fixture.
+    """
+    return CloseMasternodeTransaction()

--- a/tests/masternode/test_close.py
+++ b/tests/masternode/test_close.py
@@ -1,0 +1,32 @@
+"""
+Provide tests for command line interface's masternode close command.
+"""
+import json
+
+from click.testing import CliRunner
+
+from cli.constants import PASSED_EXIT_FROM_COMMAND_CODE
+from cli.entrypoint import cli
+
+
+def test_close_node(mocker, close_masternode_transaction):
+    """
+    Case: close the masternode.
+    Expect: close masternode transaction's batch identifier is returned.
+    """
+    mock_mock_get_node_private_key = mocker.patch('cli.config.NodePrivateKey.get')
+    mock_mock_get_node_private_key.return_value = '42dada12f863528bd456785d8c544154db6ec9455be2c123d91b687df3697314'
+
+    mock_close_masternode = mocker.patch('cli.node.service.loop.run_until_complete')
+    mock_close_masternode.return_value = close_masternode_transaction
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'masternode',
+        'close',
+    ])
+
+    node_close_transaction_identifier = json.loads(result.output).get('result').get('batch_id')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert close_masternode_transaction.batch_id == node_close_transaction_identifier

--- a/tests/masternode/test_close.py
+++ b/tests/masternode/test_close.py
@@ -9,15 +9,15 @@ from cli.constants import PASSED_EXIT_FROM_COMMAND_CODE
 from cli.entrypoint import cli
 
 
-def test_close_node(mocker, close_masternode_transaction):
+def test_close_masternode(mocker, close_masternode_transaction):
     """
     Case: close the masternode.
     Expect: close masternode transaction's batch identifier is returned.
     """
-    mock_mock_get_node_private_key = mocker.patch('cli.config.NodePrivateKey.get')
-    mock_mock_get_node_private_key.return_value = '42dada12f863528bd456785d8c544154db6ec9455be2c123d91b687df3697314'
+    mock_get_node_private_key = mocker.patch('cli.config.NodePrivateKey.get')
+    mock_get_node_private_key.return_value = '42dada12f863528bd456785d8c544154db6ec9455be2c123d91b687df3697314'
 
-    mock_close_masternode = mocker.patch('cli.node.service.loop.run_until_complete')
+    mock_close_masternode = mocker.patch('cli.masternode.service.loop.run_until_complete')
     mock_close_masternode.return_value = close_masternode_transaction
 
     runner = CliRunner()
@@ -26,7 +26,7 @@ def test_close_node(mocker, close_masternode_transaction):
         'close',
     ])
 
-    node_close_transaction_identifier = json.loads(result.output).get('result').get('batch_id')
+    masternode_close_transaction_identifier = json.loads(result.output).get('result').get('batch_id')
 
     assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
-    assert close_masternode_transaction.batch_id == node_close_transaction_identifier
+    assert close_masternode_transaction.batch_id == masternode_close_transaction_identifier


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1317

### Description
Close the masternode command line interface's command implementation.

Example of the usage:
```bash
$ remme masternode close
{
    "result": {
        "batch_id": "ae0ad8d5379beb28211cdc3f4d70a7ef66852eb815241cb201425897fc470e727c34e67ea77525ac696633afd27cca88227df52493889edcbb6fb840b4c93326"
    }
}
```

### References
- CLI framework — https://click.palletsprojects.com/en/7.x
- Library to interact with Remme-core — https://github.com/Remmeauth/remme-client-python