### PR TITLE
Implement transfer tokens from frozen to unfrozen balances CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,17 @@ $ remme node-account get \
 }
 ```
 
+Transfer available tokens from frozen to unfrozen reputation's balances (executable only on the machine which runs the node) — `remme node-account transfer-tokens-from-frozen-to-unfrozen`.
+
+```bash
+$ remme node-account transfer-tokens-from-frozen-to-unfrozen
+{
+    "result": {
+        "batch_identifier": "aac64d7b10be4b93b8c345b5eca1dc870c6b3905485e48a0ca5f58928a88a42b7a404abb4f1027e973314cca95379b1ef375358ad1661d0964c1ded4c212810f"
+    }
+}
+```
+
 ### Block
 
 Get a list of blocks — ``remme block get-list``:

--- a/cli/node_account/cli.py
+++ b/cli/node_account/cli.py
@@ -5,11 +5,14 @@ import sys
 
 import click
 from remme import Remme
+from remme.models.account.account_type import AccountType
 
+from cli.config import NodePrivateKey
 from cli.constants import (
     FAILED_EXIT_FROM_COMMAND_CODE,
     NODE_URL_ARGUMENT_HELP_MESSAGE,
 )
+from cli.errors import NotSupportedOsToGetNodePrivateKeyError
 from cli.node_account.forms import GetNodeAccountInformationForm
 from cli.node_account.help import NODE_ACCOUNT_ADDRESS_ARGUMENT_HELP_MESSAGE
 from cli.node_account.service import NodeAccount
@@ -52,6 +55,32 @@ def get(address, node_url):
     )
 
     result, errors = NodeAccount(service=remme).get(address=node_account_address)
+
+    if errors is not None:
+        print_errors(errors=errors)
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    print_result(result=result)
+
+
+@node_account_commands.command('transfer-tokens-from-frozen-to-unfrozen')
+def transfer_tokens_from_frozen_to_unfrozen():
+    """
+    Transfer available tokens from frozen to unfrozen reputation's balances.
+    """
+    try:
+        node_private_key = NodePrivateKey().get()
+
+    except (NotSupportedOsToGetNodePrivateKeyError, FileNotFoundError) as error:
+        print_errors(errors=str(error))
+        sys.exit(FAILED_EXIT_FROM_COMMAND_CODE)
+
+    remme = Remme(
+        account_config={'private_key_hex': node_private_key, 'account_type': AccountType.NODE},
+        network_config={'node_address': 'localhost' + ':8080'},
+    )
+
+    result, errors = NodeAccount(service=remme).transfer_tokens_from_frozen_to_unfrozen()
 
     if errors is not None:
         print_errors(errors=errors)

--- a/cli/node_account/interfaces.py
+++ b/cli/node_account/interfaces.py
@@ -16,3 +16,9 @@ class NodeAccountInterface:
             address (str, required): node account address to get information about node account by.
         """
         pass
+
+    def transfer_tokens_from_frozen_to_unfrozen(self):
+        """
+        Transfer available tokens from frozen to unfrozen reputation's balances.
+        """
+        pass

--- a/cli/node_account/service.py
+++ b/cli/node_account/service.py
@@ -45,3 +45,19 @@ class NodeAccount:
             return None, str(error)
 
         return node_account_information.node_account_response, None
+
+    def transfer_tokens_from_frozen_to_unfrozen(self):
+        """
+        Transfer available tokens from frozen to unfrozen reputation's balances.
+        """
+        try:
+            transaction = loop.run_until_complete(
+                self.service.token.transfer_from_frozen_to_unfrozen(),
+            )
+
+        except Exception as error:
+            return None, str(error)
+
+        return {
+            'batch_identifier': transaction.batch_id,
+        }, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,20 @@ class OpenMasternodeTransaction:
                '08f5308af03fd4aa18ff1d868f043b12dd7b0a792e141f000a2505acd4b7a956'
 
 
+class Transaction:
+    """
+    Impose transaction's data transfer object.
+    """
+
+    @property
+    def batch_id(self):
+        """
+        Get batch identifier of the transaction.
+        """
+        return '37809770b004dcbc7dae116fd9f17428255ddddee3304c9b3d14609d2792e78f' \
+               '08f5308af03fd4aa18ff1d868f043b12dd7b0a792e141f000a2505acd4b7a956'
+
+
 @pytest.fixture()
 def sent_transaction():
     """
@@ -334,3 +348,11 @@ def open_masternode_transaction():
     Get the open masternode transaction fixture.
     """
     return OpenMasternodeTransaction()
+
+
+@pytest.fixture()
+def transaction():
+    """
+    Get the transaction fixture.
+    """
+    return Transaction()

--- a/tests/node_account/test_transfer_tokens_from_frozen_to_unfrozen.py
+++ b/tests/node_account/test_transfer_tokens_from_frozen_to_unfrozen.py
@@ -1,0 +1,33 @@
+"""
+Provide tests for command line interface's node account transfer tokens from frozen to unfrozen operational balances.
+"""
+import json
+
+from click.testing import CliRunner
+
+from cli.constants import PASSED_EXIT_FROM_COMMAND_CODE
+from cli.entrypoint import cli
+
+
+def test_transfer_tokens_from_frozen_to_unfrozen(mocker, transaction):
+    """
+    Case: transfer tokens from frozen to unfrozen.
+    Expect: transaction's batch identifier is returned.
+    """
+    mock_get_node_private_key = mocker.patch('cli.config.NodePrivateKey.get')
+    mock_get_node_private_key.return_value = '42dada12f863528bd456785d8c544154db6ec9455be2c123d91b687df3697314'
+
+    mock_node_account_transfer_tokens_from_frozen_to_unfrozen = \
+        mocker.patch('cli.node_account.service.loop.run_until_complete')
+    mock_node_account_transfer_tokens_from_frozen_to_unfrozen.return_value = transaction
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        'node-account',
+        'transfer-tokens-from-frozen-to-unfrozen',
+    ])
+
+    transaction_batch_identifier = json.loads(result.output).get('result').get('batch_identifier')
+
+    assert PASSED_EXIT_FROM_COMMAND_CODE == result.exit_code
+    assert transaction.batch_id == transaction_batch_identifier


### PR DESCRIPTION
## Description

Transfer tokens from frozen to unfrozen balances CLI command implement.

Example of the usage:

```bash
$ remme node-account transfer-tokens-from-frozen-to-unfrozen
{
    "result": {
        "batch_identifier": "aac64d7b10be4b93b8c345b5eca1dc870c6b3905485e48a0ca5f58928a88a42b7a404abb4f1027e973314cca95379b1ef375358ad1661d0964c1ded4c212810f"
    }
}
```